### PR TITLE
Improvements

### DIFF
--- a/cmd/connect/cluster.go
+++ b/cmd/connect/cluster.go
@@ -46,7 +46,7 @@ devspace connect cluster
 	clusterCmd.Flags().StringVar(&cmd.Options.Key, "key", "", "The encryption key to use")
 	clusterCmd.Flags().StringVar(&cmd.Options.ClusterName, "name", "", "The cluster name to create")
 
-	clusterCmd.Flags().BoolVar(&cmd.Options.UseDomain, "use-domain", true, "Use an automatic domain for the cluster")
+	clusterCmd.Flags().BoolVar(&cmd.Options.UseDomain, "use-domain", false, "Use an automatic domain for the cluster")
 	clusterCmd.Flags().StringVar(&cmd.Options.Domain, "domain", "", "The domain to use")
 
 	return clusterCmd

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -117,7 +117,7 @@ func (cmd *DeployCmd) Run(cobraCmd *cobra.Command, args []string) {
 	}
 
 	// Create docker client
-	dockerClient, err := docker.NewClient(config, false)
+	dockerClient, err := docker.NewClient(config, false, log.GetInstance())
 
 	// Create pull secrets and private registry if necessary
 	err = registry.CreatePullSecrets(config, dockerClient, client, log.GetInstance())

--- a/cmd/dev.go
+++ b/cmd/dev.go
@@ -143,7 +143,7 @@ func (cmd *DevCmd) Run(cobraCmd *cobra.Command, args []string) {
 	}
 
 	// Create the image pull secrets and add them to the default service account
-	dockerClient, err := docker.NewClient(config, false)
+	dockerClient, err := docker.NewClient(config, false, log.GetInstance())
 	if err != nil {
 		dockerClient = nil
 	}

--- a/cmd/dev.go
+++ b/cmd/dev.go
@@ -256,7 +256,7 @@ func (cmd *DevCmd) startServices(config *latest.Config, client kubernetes.Interf
 	}
 
 	exitChan := make(chan error)
-	autoReloadPaths := GetPaths()
+	autoReloadPaths := GetPaths(config)
 
 	// Start watcher if we have at least one auto reload path and if we should not skip the pipeline
 	if cmd.SkipPipeline == false && len(autoReloadPaths) > 0 {
@@ -316,9 +316,8 @@ func (cmd *DevCmd) startServices(config *latest.Config, client kubernetes.Interf
 }
 
 // GetPaths retrieves the watch paths from the config object
-func GetPaths() []string {
+func GetPaths(config *latest.Config) []string {
 	paths := make([]string, 0, 1)
-	config := configutil.GetConfig()
 
 	// Add the deploy manifest paths
 	if config.Dev != nil && config.Dev.AutoReload != nil {

--- a/pkg/devspace/build/create_builder.go
+++ b/pkg/devspace/build/create_builder.go
@@ -23,7 +23,7 @@ func CreateBuilder(config *latest.Config, client kubernetes.Interface, imageConf
 	if imageConf.Build != nil && imageConf.Build.Custom != nil {
 		imageBuilder = custom.NewBuilder(imageConfigName, imageConf, imageTag)
 	} else if imageConf.Build != nil && imageConf.Build.Kaniko != nil {
-		dockerClient, err := dockerclient.NewClient(config, false)
+		dockerClient, err := dockerclient.NewClient(config, false, log)
 		if err != nil {
 			return nil, fmt.Errorf("Error creating docker client: %v", err)
 		}
@@ -40,7 +40,7 @@ func CreateBuilder(config *latest.Config, client kubernetes.Interface, imageConf
 			preferMinikube = *imageConf.Build.Docker.PreferMinikube
 		}
 
-		dockerClient, err := dockerclient.NewClient(config, preferMinikube)
+		dockerClient, err := dockerclient.NewClient(config, preferMinikube, log)
 		if err != nil {
 			return nil, fmt.Errorf("Error creating docker client: %v", err)
 		}

--- a/pkg/devspace/builder/docker/docker.go
+++ b/pkg/devspace/builder/docker/docker.go
@@ -163,6 +163,8 @@ func (b *Builder) BuildImage(contextPath, dockerfilePath string, entrypoint *[]*
 	relDockerfile = archive.CanonicalTarNameForPath(relDockerfile)
 
 	excludes = build.TrimBuildFilesFromExcludes(excludes, relDockerfile, false)
+	excludes = append(excludes, ".devspace/")
+
 	buildCtx, err := archive.TarWithOptions(contextDir, &archive.TarOptions{
 		ExcludePatterns: excludes,
 		ChownOpts:       &idtools.Identity{UID: 0, GID: 0},

--- a/pkg/devspace/builder/docker/docker_test.go
+++ b/pkg/devspace/builder/docker/docker_test.go
@@ -6,11 +6,11 @@ import (
 	"testing"
 
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/configutil"
-	"github.com/devspace-cloud/devspace/pkg/devspace/docker"
-	"github.com/devspace-cloud/devspace/pkg/util/randutil"
-	"github.com/devspace-cloud/devspace/pkg/util/ptr"
-	"github.com/devspace-cloud/devspace/pkg/util/log"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/versions/latest"
+	"github.com/devspace-cloud/devspace/pkg/devspace/docker"
+	"github.com/devspace-cloud/devspace/pkg/util/log"
+	"github.com/devspace-cloud/devspace/pkg/util/ptr"
+	"github.com/devspace-cloud/devspace/pkg/util/randutil"
 )
 
 //@Moretest
@@ -75,7 +75,7 @@ func TestDockerBuild(t *testing.T) {
 	}
 	configutil.SetFakeConfig(testConfig)
 
-	dockerClient, err := docker.NewClient(testConfig, true)
+	dockerClient, err := docker.NewClient(testConfig, true, log.GetInstance())
 	if err != nil {
 		t.Fatalf("Error creating docker client: %v", err)
 	}
@@ -97,7 +97,7 @@ func TestDockerBuild(t *testing.T) {
 			Docker: &latest.DockerConfig{
 				Options: &latest.BuildOptions{
 					BuildArgs: &buildArgs,
-					Network: &network,
+					Network:   &network,
 				},
 			},
 		},
@@ -110,7 +110,7 @@ func TestDockerBuild(t *testing.T) {
 	err = imageBuilder.BuildImage(dir, "Dockerfile", nil, log.GetInstance())
 	if err != nil {
 		t.Fatalf("Image building failed: %v", err)
-	} 
+	}
 
 }
 
@@ -173,7 +173,7 @@ func TestDockerbuildWithEntryppointOverride(t *testing.T) {
 	}
 	configutil.SetFakeConfig(testConfig)
 
-	dockerClient, err := docker.NewClient(testConfig, true)
+	dockerClient, err := docker.NewClient(testConfig, true, log.GetInstance())
 	if err != nil {
 		t.Fatalf("Error creating docker client: %v", err)
 	}
@@ -203,7 +203,6 @@ func TestDockerbuildWithEntryppointOverride(t *testing.T) {
 		t.Fatalf("Image building failed: %v", err)
 	}
 }
-
 
 func makeTestProject(dir string) error {
 	file, err := os.Create("package.json")

--- a/pkg/devspace/builder/kaniko/kaniko.go
+++ b/pkg/devspace/builder/kaniko/kaniko.go
@@ -214,11 +214,12 @@ func (b *Builder) BuildImage(contextPath, dockerfilePath string, entrypoint *[]*
 		}
 
 		// Get ignore rules from docker ignore
-		ignoreRules, ignoreRuleErr := ignoreutil.GetIgnoreRules(contextPath)
-		if ignoreRuleErr != nil {
-			return fmt.Errorf("Unable to parse .dockerignore files: %s", ignoreRuleErr.Error())
+		ignoreRules, err := ignoreutil.GetIgnoreRules(contextPath)
+		if err != nil {
+			return fmt.Errorf("Unable to parse .dockerignore files: %s", err.Error())
 		}
 
+		ignoreRules = append(ignoreRules, ".devspace/")
 		log.StartWait("Uploading files to build container")
 
 		// Copy complete context

--- a/pkg/devspace/cloud/login.go
+++ b/pkg/devspace/cloud/login.go
@@ -85,7 +85,7 @@ func ReLogin(providerConfig ProviderConfig, cloudProvider string, key *string, l
 	log.Donef("Successfully logged into %s", provider.Name)
 
 	// Login into registries
-	err := provider.LoginIntoRegistries()
+	err := provider.LoginIntoRegistries(log)
 	if err != nil {
 		log.Warnf("Error logging into docker registries: %v", err)
 	}
@@ -123,7 +123,7 @@ func EnsureLoggedIn(providerConfig ProviderConfig, cloudProvider string, log log
 		log.Donef("Successfully logged into %s", provider.Name)
 
 		// Login into registries
-		err = provider.LoginIntoRegistries()
+		err = provider.LoginIntoRegistries(log)
 		if err != nil {
 			log.Warnf("Error logging into docker registries: %v", err)
 		}

--- a/pkg/devspace/cloud/registry.go
+++ b/pkg/devspace/cloud/registry.go
@@ -24,14 +24,14 @@ func (p *Provider) GetFirstPublicRegistry() (string, error) {
 }
 
 // LoginIntoRegistries logs the user into the user docker registries
-func (p *Provider) LoginIntoRegistries() error {
+func (p *Provider) LoginIntoRegistries(log log.Logger) error {
 	registries, err := p.GetRegistries()
 	if err != nil {
 		return errors.Wrap(err, "get registries")
 	}
 
 	// We don't want the minikube client to login into the registry
-	client, err := docker.NewClient(nil, false)
+	client, err := docker.NewClient(nil, false, log)
 	if err != nil {
 		return errors.Wrap(err, "new docker client")
 	}
@@ -63,9 +63,9 @@ func (p *Provider) LoginIntoRegistries() error {
 }
 
 // LoginIntoRegistry logs the user into the user docker registry
-func (p *Provider) LoginIntoRegistry(name string) error {
+func (p *Provider) LoginIntoRegistry(name string, log log.Logger) error {
 	// We don't want the minikube client to login into the registry
-	client, err := docker.NewClient(nil, false)
+	client, err := docker.NewClient(nil, false, log)
 	if err != nil {
 		return errors.Wrap(err, "new docker client")
 	}

--- a/pkg/devspace/configure/image.go
+++ b/pkg/devspace/configure/image.go
@@ -77,7 +77,7 @@ func GetImageConfigFromDockerfile(config *latest.Config, dockerfile, context str
 	)
 
 	// Get docker client
-	client, err := docker.NewClient(config, true)
+	client, err := docker.NewClient(config, true, log.GetInstance())
 	if err != nil {
 		return nil, fmt.Errorf("Cannot create docker client: %v", err)
 	}

--- a/pkg/devspace/configure/image.go
+++ b/pkg/devspace/configure/image.go
@@ -197,7 +197,7 @@ func GetImageConfigFromDockerfile(config *latest.Config, dockerfile, context str
 		defaultImageName = survey.Question(&survey.QuestionOptions{
 			Question:               "Which image name do you want to push to?",
 			DefaultValue:           registryURL + "/" + dockerUsername + "/devspace",
-			ValidationRegexPattern: "^[a-zA-Z0-9\\./-]{4,90}$",
+			ValidationRegexPattern: "^.*$",
 		})
 	}
 

--- a/pkg/devspace/dependency/dependency.go
+++ b/pkg/devspace/dependency/dependency.go
@@ -206,7 +206,7 @@ func (d *Dependency) Deploy(skipPush bool, forceDependencies, forceBuild, forceD
 	}
 
 	// Create docker client
-	dockerClient, err := docker.NewClient(d.Config, false)
+	dockerClient, err := docker.NewClient(d.Config, false, log)
 
 	// Create pull secrets and private registry if necessary
 	err = registry.CreatePullSecrets(d.Config, dockerClient, client, log)

--- a/pkg/devspace/generator/language.go
+++ b/pkg/devspace/generator/language.go
@@ -165,7 +165,7 @@ func (cg *DockerfileGenerator) CreateDockerfile(language string) error {
 	}
 
 	// Copy dockerfile
-	err = fsutil.Copy(filepath.Join(cg.gitRepo.LocalPath, cg.Language), ".", false)
+	err = fsutil.Copy(filepath.Join(cg.gitRepo.LocalPath, language), ".", false)
 	if err != nil {
 		return err
 	}

--- a/pkg/devspace/sync/sync.go
+++ b/pkg/devspace/sync/sync.go
@@ -437,21 +437,23 @@ func (s *Sync) Stop(fatalError error) {
 			}
 
 			close(s.upstream.interrupt)
-			if s.upstream.reader != nil {
-				s.upstream.reader.Close()
-			}
 			if s.upstream.writer != nil {
 				s.upstream.writer.Close()
+			}
+			if s.upstream.reader != nil {
+				// Closing the reader is hanging on windows so we skip that
+				// s.upstream.reader.Close()
 			}
 		}
 
 		if s.downstream != nil && s.downstream.interrupt != nil {
 			close(s.downstream.interrupt)
-			if s.downstream.reader != nil {
-				s.downstream.reader.Close()
-			}
 			if s.downstream.writer != nil {
 				s.downstream.writer.Close()
+			}
+			if s.downstream.reader != nil {
+				// Closing the reader is hanging on windows so we skip that
+				// s.downstream.reader.Close()
 			}
 		}
 

--- a/pkg/devspace/sync/sync.go
+++ b/pkg/devspace/sync/sync.go
@@ -195,7 +195,6 @@ func (s *Sync) mainLoop() {
 	// Start downstream and do initial sync
 	go func() {
 		defer s.Stop(nil)
-
 		err := s.initialSync()
 		if err != nil {
 			s.Stop(errors.Wrap(err, "initial sync"))


### PR DESCRIPTION
This pull request changes the following things:
- Don't ask for domain on `devspace cluster connect`
- Fixes an issue where it was not possible to enter a custom registry with port during `devspace init` (#557)
- Fixes an issue where sync was not closing correctly on windows
- Fixes an issue where wrongly configured docker environment variables lead to an error
- Automatically append the .devspace folder to dockerignore during build
- Fixes an issue where the selected language none during devspace init would result in a wrong Dockerfile