### PR TITLE
Parse image name correctly & fix #559

### DIFF
--- a/cmd/open.go
+++ b/cmd/open.go
@@ -185,7 +185,7 @@ func (cmd *OpenCmd) RunOpen(cobraCmd *cobra.Command, args []string) {
 	defer log.StopWait()
 
 	// Make sure the ingress has some time to take effect
-	time.Sleep(time.Second * 5)
+	time.Sleep(time.Second * 2)
 
 	now := time.Now()
 	for time.Since(now) < time.Minute*4 {

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -184,6 +184,9 @@ func (cmd *OpenCmd) RunOpen(cobraCmd *cobra.Command, args []string) {
 	log.StartWait("Waiting for ingress")
 	defer log.StopWait()
 
+	// Make sure the ingress has some time to take effect
+	time.Sleep(time.Second * 5)
+
 	now := time.Now()
 	for time.Since(now) < time.Minute*4 {
 		// Check if domain is ready

--- a/pkg/devspace/config/constants/constants.go
+++ b/pkg/devspace/config/constants/constants.go
@@ -14,3 +14,6 @@ const DefaultDevSpaceSelectorName = "app-selector"
 
 // DefaultHomeDevSpaceFolder is the default .devspace home folder where to store specific configurations
 const DefaultHomeDevSpaceFolder = ".devspace"
+
+// DevSpaceCloudNamespace is the namespace of the devspace cloud components
+const DevSpaceCloudNamespace = "devspace-cloud"

--- a/pkg/devspace/deploy/kubectl/kubectl.go
+++ b/pkg/devspace/deploy/kubectl/kubectl.go
@@ -14,6 +14,7 @@ import (
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/generated"
 	"github.com/devspace-cloud/devspace/pkg/devspace/deploy"
 	"github.com/devspace-cloud/devspace/pkg/devspace/deploy/kubectl/walk"
+	"github.com/devspace-cloud/devspace/pkg/devspace/registry"
 
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/versions/latest"
 	"github.com/devspace-cloud/devspace/pkg/util/hash"
@@ -297,18 +298,16 @@ func replaceManifest(manifest map[interface{}]interface{}, cache *generated.Cach
 
 	match := func(path, key, value string) bool {
 		if key == "image" {
-			value = strings.TrimSpace(value)
-
-			image := strings.Split(value, ":")
-			if len(image) > 2 {
+			image, err := registry.GetStrippedDockerImageName(value)
+			if err != nil {
 				return false
 			}
 
 			// Search for image name
 			for _, imageCache := range cache.Images {
-				if imageCache.ImageName == image[0] && imageCache.Tag != "" {
+				if imageCache.ImageName == image && imageCache.Tag != "" {
 					if builtImages != nil {
-						if _, ok := builtImages[image[0]]; ok {
+						if _, ok := builtImages[image]; ok {
 							shouldRedeploy = true
 						}
 					}
@@ -322,13 +321,15 @@ func replaceManifest(manifest map[interface{}]interface{}, cache *generated.Cach
 	}
 
 	replace := func(path, value string) interface{} {
-		value = strings.TrimSpace(value)
-		image := strings.Split(value, ":")
+		image, err := registry.GetStrippedDockerImageName(value)
+		if err != nil {
+			return false
+		}
 
 		// Search for image name
 		for _, imageCache := range cache.Images {
-			if imageCache.ImageName == image[0] {
-				return image[0] + ":" + imageCache.Tag
+			if imageCache.ImageName == image {
+				return image + ":" + imageCache.Tag
 			}
 		}
 

--- a/pkg/devspace/registry/util.go
+++ b/pkg/devspace/registry/util.go
@@ -1,6 +1,8 @@
 package registry
 
 import (
+	"strings"
+
 	"github.com/docker/distribution/reference"
 	dockerregistry "github.com/docker/docker/registry"
 )
@@ -22,4 +24,27 @@ func GetRegistryFromImageName(imageName string) (string, error) {
 	}
 
 	return repoInfo.Index.Name, nil
+}
+
+// GetStrippedDockerImageName returns a tag stripped image name and checks if it's a valid image name
+func GetStrippedDockerImageName(imageName string) (string, error) {
+	imageName = strings.TrimSpace(imageName)
+
+	// Check if we can parse the name
+	ref, err := reference.ParseNormalizedNamed(imageName)
+	if err != nil {
+		return "", err
+	}
+
+	repoInfo, err := dockerregistry.ParseRepositoryInfo(ref)
+	if err != nil {
+		return "", err
+	}
+
+	if repoInfo.Index.Official {
+		// strip docker.io and library from image
+		return strings.TrimPrefix(strings.TrimPrefix(reference.TrimNamed(ref).Name(), repoInfo.Index.Name+"/library/"), repoInfo.Index.Name+"/"), nil
+	}
+
+	return reference.TrimNamed(ref).Name(), nil
 }


### PR DESCRIPTION
This pull request introduces the following changes:
- Fix #559 & implement unit test for correct image name replacement
- Verify image name during init with docker instead of regex
- Strip tags from image name during devspace init
- On `devspace connect cluster` a default cluster spaces url is configured