### PR TITLE
Improve init and dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Stop wasting time for running the same build and deploy commands over and over a
 ### Powerful Configuration
 - **Declarative Configuration File** that can be versioned and shared just like the source code of your project (e.g. via git)
 - **Config Variables** which allow you to parameterize the config and share a unified config file with your team
-- **Config Overrides** for overriding Dockerfiles or ENTRPOINTs (e.g. to separate development, staging and production)
+- **Config Overrides** for overriding Dockerfiles or ENTRYPOINTs (e.g. to separate development, staging and production)
 - **Hooks** for executing custom commands before or after each build and deployment step
 - **Multiple Configs** for advanced deployment scenarios
 

--- a/cmd/add/deployment.go
+++ b/cmd/add/deployment.go
@@ -24,6 +24,9 @@ type deploymentCmd struct {
 
 	Dockerfile string
 	Context    string
+
+	// mainly used for testing
+	disableRegistryAuth bool
 }
 
 func newDeploymentCmd() *cobra.Command {
@@ -118,7 +121,7 @@ func (cmd *deploymentCmd) RunAddDeployment(cobraCmd *cobra.Command, args []strin
 			log.Fatal(err)
 		}
 
-		newImage, newDeployment, err = configure.GetDockerfileComponentDeployment(config, generatedConfig, deploymentName, cmd.Image, cmd.Dockerfile, cmd.Context, true)
+		newImage, newDeployment, err = configure.GetDockerfileComponentDeployment(config, generatedConfig, deploymentName, cmd.Image, cmd.Dockerfile, cmd.Context, !cmd.disableRegistryAuth)
 	} else if cmd.Image != "" {
 		newImage, newDeployment, err = configure.GetImageComponentDeployment(deploymentName, cmd.Image)
 	} else if cmd.Component != "" {

--- a/cmd/add/deployment.go
+++ b/cmd/add/deployment.go
@@ -118,7 +118,7 @@ func (cmd *deploymentCmd) RunAddDeployment(cobraCmd *cobra.Command, args []strin
 			log.Fatal(err)
 		}
 
-		newImage, newDeployment, err = configure.GetDockerfileComponentDeployment(config, generatedConfig, deploymentName, cmd.Image, cmd.Dockerfile, cmd.Context)
+		newImage, newDeployment, err = configure.GetDockerfileComponentDeployment(config, generatedConfig, deploymentName, cmd.Image, cmd.Dockerfile, cmd.Context, "")
 	} else if cmd.Image != "" {
 		newImage, newDeployment, err = configure.GetImageComponentDeployment(deploymentName, cmd.Image)
 	} else if cmd.Component != "" {

--- a/cmd/add/deployment.go
+++ b/cmd/add/deployment.go
@@ -118,7 +118,7 @@ func (cmd *deploymentCmd) RunAddDeployment(cobraCmd *cobra.Command, args []strin
 			log.Fatal(err)
 		}
 
-		newImage, newDeployment, err = configure.GetDockerfileComponentDeployment(config, generatedConfig, deploymentName, cmd.Image, cmd.Dockerfile, cmd.Context)
+		newImage, newDeployment, err = configure.GetDockerfileComponentDeployment(config, generatedConfig, deploymentName, cmd.Image, cmd.Dockerfile, cmd.Context, true)
 	} else if cmd.Image != "" {
 		newImage, newDeployment, err = configure.GetImageComponentDeployment(deploymentName, cmd.Image)
 	} else if cmd.Component != "" {

--- a/cmd/add/deployment.go
+++ b/cmd/add/deployment.go
@@ -118,7 +118,7 @@ func (cmd *deploymentCmd) RunAddDeployment(cobraCmd *cobra.Command, args []strin
 			log.Fatal(err)
 		}
 
-		newImage, newDeployment, err = configure.GetDockerfileComponentDeployment(config, generatedConfig, deploymentName, cmd.Image, cmd.Dockerfile, cmd.Context, "")
+		newImage, newDeployment, err = configure.GetDockerfileComponentDeployment(config, generatedConfig, deploymentName, cmd.Image, cmd.Dockerfile, cmd.Context)
 	} else if cmd.Image != "" {
 		newImage, newDeployment, err = configure.GetImageComponentDeployment(deploymentName, cmd.Image)
 	} else if cmd.Component != "" {

--- a/cmd/add/deployment_test.go
+++ b/cmd/add/deployment_test.go
@@ -137,7 +137,7 @@ func TestRunAddDeployment(t *testing.T) {
 		addDeploymentTestCase{
 			name:    "Valid image deployment",
 			args:    []string{"newImageDeployment"},
-			answers: []string{"1234", "yes"},
+			answers: []string{"1234"},
 			fakeConfig: &latest.Config{
 				Images: &map[string]*latest.ImageConfig{
 					"someImage": &latest.ImageConfig{
@@ -232,6 +232,7 @@ func testRunAddDeployment(t *testing.T, testCase addDeploymentTestCase) {
 		Image:        testCase.cmdImage,
 		Context:      testCase.cmdContext,
 		Namespace:    testCase.cmdNamespace,
+		disableRegistryAuth:    true,
 	}).RunAddDeployment(nil, testCase.args)
 
 	assert.Equal(t, logOutput, testCase.expectedOutput, "Unexpected output in testCase %s", testCase.name)

--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -55,16 +55,21 @@ func (cmd *AnalyzeCmd) RunAnalyze(cobraCmd *cobra.Command, args []string) {
 	}
 
 	var devSpaceConfig *latest.Config
-	if configExists {
-		devSpaceConfig = configutil.GetConfig()
-
+	if configutil.ConfigExists() {
+		// Load generated config
 		generatedConfig, err := generated.LoadConfig()
+		if err != nil {
+			log.Fatalf("Error loading generated.yaml: %v", err)
+		}
+
+		// Get config with adjusted cluster config
+		config, err := configutil.GetContextAjustedConfig(cmd.Namespace, "")
 		if err != nil {
 			log.Fatal(err)
 		}
 
 		// Signal that we are working on the space if there is any
-		err = cloud.ResumeSpace(devSpaceConfig, generatedConfig, true, log.GetInstance())
+		err = cloud.ResumeSpace(config, generatedConfig, true, log.GetInstance())
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -63,7 +63,7 @@ func (cmd *AnalyzeCmd) RunAnalyze(cobraCmd *cobra.Command, args []string) {
 		}
 
 		// Get config with adjusted cluster config
-		config, err := configutil.GetContextAjustedConfig(cmd.Namespace, "")
+		config, err := configutil.GetContextAdjustedConfig(cmd.Namespace, "", false)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -4,7 +4,6 @@ import (
 	"github.com/devspace-cloud/devspace/pkg/devspace/analyze"
 	"github.com/devspace-cloud/devspace/pkg/devspace/cloud"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/configutil"
-	"github.com/devspace-cloud/devspace/pkg/devspace/config/generated"
 	latest "github.com/devspace-cloud/devspace/pkg/devspace/config/versions/latest"
 	"github.com/devspace-cloud/devspace/pkg/devspace/kubectl"
 	"github.com/devspace-cloud/devspace/pkg/util/log"
@@ -56,12 +55,6 @@ func (cmd *AnalyzeCmd) RunAnalyze(cobraCmd *cobra.Command, args []string) {
 
 	var devSpaceConfig *latest.Config
 	if configutil.ConfigExists() {
-		// Load generated config
-		generatedConfig, err := generated.LoadConfig()
-		if err != nil {
-			log.Fatalf("Error loading generated.yaml: %v", err)
-		}
-
 		// Get config with adjusted cluster config
 		config, err := configutil.GetContextAdjustedConfig(cmd.Namespace, "", false)
 		if err != nil {
@@ -69,7 +62,7 @@ func (cmd *AnalyzeCmd) RunAnalyze(cobraCmd *cobra.Command, args []string) {
 		}
 
 		// Signal that we are working on the space if there is any
-		err = cloud.ResumeSpace(config, generatedConfig, true, log.GetInstance())
+		err = cloud.ResumeLatestSpace(config, true, log.GetInstance())
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/connect/cluster.go
+++ b/cmd/connect/cluster.go
@@ -77,5 +77,5 @@ func (cmd *clusterCmd) RunConnectCluster(cobraCmd *cobra.Command, args []string)
 		log.Fatal(err)
 	}
 
-	log.Donef("Successfully connected cluster to DevSpace Cloud. You can now run:\n- `%s` to create a new space\n- `%s` to open the ui and configure cluster access and users\n- `%s` to list all connected clusters", ansi.Color("devspace create space [NAME]", "white+b"), ansi.Color("devspace ui", "white+b"), ansi.Color("devspace list clusters", "white+b"))
+	log.Donef("Successfully connected cluster to DevSpace Cloud. \n\nYou can now run:\n- `%s` to create a new space\n- `%s` to open the ui and configure cluster access and users\n- `%s` to list all connected clusters", ansi.Color("devspace create space [NAME]", "white+b"), ansi.Color("devspace ui", "white+b"), ansi.Color("devspace list clusters", "white+b"))
 }

--- a/cmd/containerize.go
+++ b/cmd/containerize.go
@@ -17,8 +17,9 @@ func NewContainerizeCmd() *cobra.Command {
 	cmd := &ContainerizeCmd{}
 
 	containerizeCmd := &cobra.Command{
-		Use:   "containerize",
-		Short: "Creates a Dockerfile in the project",
+		Use:        "containerize",
+		Short:      "Creates a Dockerfile in the project",
+		Deprecated: "devspace containerize is deprecated. Use devspace init instead.",
 		Long: `
 #######################################################
 ################ devspace containerize ################

--- a/cmd/create/space.go
+++ b/cmd/create/space.go
@@ -3,7 +3,6 @@ package create
 import (
 	"github.com/devspace-cloud/devspace/pkg/devspace/cloud"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/configutil"
-	"github.com/devspace-cloud/devspace/pkg/devspace/config/generated"
 	"github.com/devspace-cloud/devspace/pkg/util/log"
 	"github.com/devspace-cloud/devspace/pkg/util/survey"
 
@@ -134,21 +133,6 @@ func (cmd *spaceCmd) RunCreateSpace(cobraCmd *cobra.Command, args []string) {
 	err = cloud.SetTillerNamespace(serviceAccount)
 	if err != nil {
 		// log.Warnf("Couldn't set tiller namespace environment variable: %v", err)
-	}
-
-	// Set space as active space
-	if cmd.Active && configExists {
-		// Get generated config
-		generatedConfig, err := generated.LoadConfig()
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		// Cache space
-		err = provider.CacheSpace(generatedConfig, space)
-		if err != nil {
-			log.Fatal(err)
-		}
 	}
 
 	log.StopWait()

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -101,7 +101,7 @@ func (cmd *DeployCmd) Run(cobraCmd *cobra.Command, args []string) {
 	}
 
 	// Get config with adjusted cluster config
-	config, err := configutil.GetContextAjustedConfig(cmd.Namespace, cmd.KubeContext)
+	config, err := configutil.GetContextAdjustedConfig(cmd.Namespace, cmd.KubeContext, true)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -107,7 +107,7 @@ func (cmd *DeployCmd) Run(cobraCmd *cobra.Command, args []string) {
 	}
 
 	// Signal that we are working on the space if there is any
-	err = cloud.ResumeSpace(config, generatedConfig, true, log.GetInstance())
+	err = cloud.ResumeLatestSpace(config, true, log.GetInstance())
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -192,11 +192,7 @@ func (cmd *DeployCmd) Run(cobraCmd *cobra.Command, args []string) {
 
 	log.Donef("Successfully deployed!")
 
-	if generatedConfig.CloudSpace != nil {
-		log.Infof("\r          \nRun: \n- `%s` to create an ingress for the app and open it in the browser \n- `%s` to open a shell into the container \n- `%s` to show the container logs\n- `%s` to open the management ui\n- `%s` to analyze the space for potential issues\n", ansi.Color("devspace open", "white+b"), ansi.Color("devspace enter", "white+b"), ansi.Color("devspace logs", "white+b"), ansi.Color("devspace ui", "white+b"), ansi.Color("devspace analyze", "white+b"))
-	} else {
-		log.Infof("\r          \nRun: \n- `%s` to open a shell into the container \n- `%s` to show the container logs\n- `%s` to analyze the namespace for potential issues\n", ansi.Color("devspace enter", "white+b"), ansi.Color("devspace logs", "white+b"), ansi.Color("devspace analyze", "white+b"))
-	}
+	log.Infof("\r          \nRun: \n- `%s` to create an ingress for the app and open it in the browser \n- `%s` to open a shell into the container \n- `%s` to show the container logs\n- `%s` to open the management ui\n- `%s` to analyze the space for potential issues\n", ansi.Color("devspace open", "white+b"), ansi.Color("devspace enter", "white+b"), ansi.Color("devspace logs", "white+b"), ansi.Color("devspace ui", "white+b"), ansi.Color("devspace analyze", "white+b"))
 }
 
 func (cmd *DeployCmd) validateFlags() {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -8,8 +8,6 @@ import (
 	"github.com/devspace-cloud/devspace/pkg/devspace/cloud"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/configutil"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/generated"
-	latest "github.com/devspace-cloud/devspace/pkg/devspace/config/versions/latest"
-	v1 "github.com/devspace-cloud/devspace/pkg/devspace/config/versions/latest"
 	"github.com/devspace-cloud/devspace/pkg/devspace/dependency"
 	deploy "github.com/devspace-cloud/devspace/pkg/devspace/deploy/util"
 	"github.com/devspace-cloud/devspace/pkg/devspace/docker"
@@ -102,8 +100,11 @@ func (cmd *DeployCmd) Run(cobraCmd *cobra.Command, args []string) {
 		log.Fatalf("Error loading generated.yaml: %v", err)
 	}
 
-	// Prepare the config
-	config := cmd.loadConfig(generatedConfig)
+	// Get config with adjusted cluster config
+	config, err := configutil.GetContextAjustedConfig(cmd.Namespace, cmd.KubeContext)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	// Signal that we are working on the space if there is any
 	err = cloud.ResumeSpace(config, generatedConfig, true, log.GetInstance())
@@ -189,12 +190,12 @@ func (cmd *DeployCmd) Run(cobraCmd *cobra.Command, args []string) {
 		log.Fatalf("Error saving generated config: %v", err)
 	}
 
+	log.Donef("Successfully deployed!")
+
 	if generatedConfig.CloudSpace != nil {
-		log.Donef("Successfully deployed!")
 		log.Infof("\r          \nRun: \n- `%s` to create an ingress for the app and open it in the browser \n- `%s` to open a shell into the container \n- `%s` to show the container logs\n- `%s` to open the management ui\n- `%s` to analyze the space for potential issues\n", ansi.Color("devspace open", "white+b"), ansi.Color("devspace enter", "white+b"), ansi.Color("devspace logs", "white+b"), ansi.Color("devspace ui", "white+b"), ansi.Color("devspace analyze", "white+b"))
 	} else {
-		log.Donef("Successfully deployed!")
-		log.Infof("Run `%s` to check for potential issues", ansi.Color("devspace analyze", "white+b"))
+		log.Infof("\r          \nRun: \n- `%s` to open a shell into the container \n- `%s` to show the container logs\n- `%s` to analyze the namespace for potential issues\n", ansi.Color("devspace enter", "white+b"), ansi.Color("devspace logs", "white+b"), ansi.Color("devspace analyze", "white+b"))
 	}
 }
 
@@ -202,38 +203,4 @@ func (cmd *DeployCmd) validateFlags() {
 	if cmd.SkipBuild && cmd.ForceBuild {
 		log.Fatal("Flags --skip-build & --force-build cannot be used together")
 	}
-}
-
-func (cmd *DeployCmd) loadConfig(generatedConfig *generated.Config) *latest.Config {
-	// Load Config and modify it
-	config, err := configutil.GetConfigFromPath(".", generatedConfig.ActiveConfig, true, generatedConfig, log.GetInstance())
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	if cmd.Namespace != "" {
-		config.Cluster = &v1.Cluster{
-			Namespace:   &cmd.Namespace,
-			KubeContext: config.Cluster.KubeContext,
-		}
-
-		log.Infof("Using %s namespace for deploying", cmd.Namespace)
-	}
-
-	if cmd.KubeContext != "" {
-		config.Cluster = &v1.Cluster{
-			Namespace:   config.Cluster.Namespace,
-			KubeContext: &cmd.KubeContext,
-		}
-
-		log.Infof("Using %s kube context for deploying", cmd.KubeContext)
-	}
-
-	// Save generated config
-	err = generated.SaveConfig(generatedConfig)
-	if err != nil {
-		log.Fatalf("Couldn't save generated config: %v", err)
-	}
-
-	return config
 }

--- a/cmd/dev.go
+++ b/cmd/dev.go
@@ -423,7 +423,7 @@ func (r *reloadError) Error() string {
 
 func (cmd *DevCmd) loadConfig(generatedConfig *generated.Config) *latest.Config {
 	// Get config with adjusted cluster config
-	config, err := configutil.GetContextAjustedConfig(cmd.Namespace, "")
+	config, err := configutil.GetContextAdjustedConfig(cmd.Namespace, "", false)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/dev.go
+++ b/cmd/dev.go
@@ -142,7 +142,7 @@ func (cmd *DevCmd) Run(cobraCmd *cobra.Command, args []string) {
 	config := cmd.loadConfig(generatedConfig)
 
 	// Signal that we are working on the space if there is any
-	err = cloud.ResumeSpace(config, generatedConfig, true, log.GetInstance())
+	err = cloud.ResumeLatestSpace(config, true, log.GetInstance())
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/dev.go
+++ b/cmd/dev.go
@@ -57,7 +57,7 @@ type DevCmd struct {
 	Namespace       string
 }
 
-var interactiveDefaultPickerValue = "Open Picker"
+const interactiveDefaultPickerValue = "Open Picker"
 
 // NewDevCmd creates a new devspace dev command
 func NewDevCmd() *cobra.Command {

--- a/cmd/dev.go
+++ b/cmd/dev.go
@@ -25,6 +25,8 @@ import (
 	"github.com/devspace-cloud/devspace/pkg/devspace/services"
 	"github.com/devspace-cloud/devspace/pkg/util/analytics/cloudanalytics"
 	"github.com/devspace-cloud/devspace/pkg/util/log"
+	"github.com/devspace-cloud/devspace/pkg/util/ptr"
+	"github.com/devspace-cloud/devspace/pkg/util/survey"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/kubernetes"
 )
@@ -48,11 +50,14 @@ type DevCmd struct {
 	SwitchContext   bool
 	Portforwarding  bool
 	VerboseSync     bool
+	Interactive     string
 	Selector        string
 	Container       string
 	LabelSelector   string
 	Namespace       string
 }
+
+var interactiveDefaultPickerValue = "Open Picker"
 
 // NewDevCmd creates a new devspace dev command
 func NewDevCmd() *cobra.Command {
@@ -102,6 +107,11 @@ Starts your project in development mode:
 
 	devCmd.Flags().BoolVar(&cmd.SwitchContext, "switch-context", true, "Switch kubectl context to the DevSpace context")
 	devCmd.Flags().BoolVar(&cmd.ExitAfterDeploy, "exit-after-deploy", false, "Exits the command after building the images and deploying the project")
+
+	devCmd.Flags().StringVarP(&cmd.Interactive, "interactive", "i", interactiveDefaultPickerValue, "Enable interactive mode for images (overrides entrypoint with sleep command) and start terminal proxy")
+
+	// Allows to use `devspace dev -i` without providing a value for the flag, see https://github.com/spf13/pflag#setting-no-option-default-values-for-flags
+	devCmd.Flags().Lookup("interactive").NoOptDefVal = interactiveDefaultPickerValue
 
 	return devCmd
 }
@@ -432,6 +442,74 @@ func (cmd *DevCmd) loadConfig(generatedConfig *generated.Config) *latest.Config 
 	err = generated.SaveConfig(generatedConfig)
 	if err != nil {
 		log.Fatalf("Couldn't save generated config: %v", err)
+	}
+
+	// Adjust config for interactive mode
+	if cmd.Interactive != "" {
+		if config.Images == nil {
+			log.Fatal("Your configuration does not contain any images to build for interactive mode. If you simply want to start the terminal instead of streaming the logs, run `devspace dev -t`")
+		}
+		images := *config.Images
+
+		if cmd.Interactive == interactiveDefaultPickerValue {
+			imageNames := make([]string, 0, len(images))
+			for k := range images {
+				imageNames = append(imageNames, k)
+			}
+
+			// If only one image exists, use it, otherwise show image picker
+			if len(imageNames) == 1 {
+				cmd.Interactive = imageNames[0]
+			} else {
+				cmd.Interactive = survey.Question(&survey.QuestionOptions{
+					Question:     "Which image do you want to build using the 'ENTRPOINT [sleep, 999999]' override?\nIf you want to apply this override to multiple images run `devspace dev -i image1,image2,...`",
+					DefaultValue: useDevSpaceCloud,
+					Options:      imageNames,
+				})
+			}
+		}
+
+		// Make sure dev section exists in config
+		if config.Dev == nil {
+			config.Dev = &latest.DevConfig{}
+		}
+
+		// Make sure dev.overrideImages section exists in config
+		if config.Dev.OverrideImages == nil {
+			imageOverrideConfig := []*latest.ImageOverrideConfig{}
+			config.Dev.OverrideImages = &imageOverrideConfig
+		}
+		imageOverrideConfig := *config.Dev.OverrideImages
+
+		// Entrypoint used for interactive mode
+		entrypointOverride := []*string{
+			ptr.String("sleep"),
+			ptr.String("999999"),
+		}
+
+		// Set all entrypoint overrides for specified interactive images
+		interactiveImages := strings.Split(cmd.Interactive, ",")
+		for i := range interactiveImages {
+			imageName := strings.TrimSpace(interactiveImages[i])
+			if _, ok := images[imageName]; !ok {
+				log.Fatalf("Unable to find image '%s' in configuration", imageName)
+			}
+			imageOverrideConfig = append(imageOverrideConfig, &latest.ImageOverrideConfig{
+				Name:       &imageName,
+				Entrypoint: &entrypointOverride,
+			})
+			log.Infof("Interactive mode: override image %s with 'ENTRYPOINT [sleep, 999999]'", imageName)
+		}
+		config.Dev.OverrideImages = &imageOverrideConfig
+
+		// Make sure dev.terminal section exists in config
+		if config.Dev.Terminal == nil {
+			config.Dev.Terminal = &latest.Terminal{}
+		}
+
+		// Set dev.terminal.disabled = false
+		config.Dev.Terminal.Disabled = ptr.Bool(false)
+		log.Info("Interactive mode: enable terminal")
 	}
 
 	return config

--- a/cmd/dev.go
+++ b/cmd/dev.go
@@ -446,7 +446,7 @@ func (cmd *DevCmd) loadConfig(generatedConfig *generated.Config) *latest.Config 
 
 	// Adjust config for interactive mode
 	if cmd.Interactive != "" {
-		if config.Images == nil {
+		if config.Images == nil || len(*config.Images) == 0 {
 			log.Fatal("Your configuration does not contain any images to build for interactive mode. If you simply want to start the terminal instead of streaming the logs, run `devspace dev -t`")
 		}
 		images := *config.Images
@@ -462,9 +462,8 @@ func (cmd *DevCmd) loadConfig(generatedConfig *generated.Config) *latest.Config 
 				cmd.Interactive = imageNames[0]
 			} else {
 				cmd.Interactive = survey.Question(&survey.QuestionOptions{
-					Question:     "Which image do you want to build using the 'ENTRPOINT [sleep, 999999]' override?\nIf you want to apply this override to multiple images run `devspace dev -i image1,image2,...`",
-					DefaultValue: useDevSpaceCloud,
-					Options:      imageNames,
+					Question: "Which image do you want to build using the 'ENTRPOINT [sleep, 999999]' override?\nIf you want to apply this override to multiple images run `devspace dev -i image1,image2,...`",
+					Options:  imageNames,
 				})
 			}
 		}

--- a/cmd/enter.go
+++ b/cmd/enter.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/devspace-cloud/devspace/pkg/devspace/cloud"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/configutil"
-	"github.com/devspace-cloud/devspace/pkg/devspace/config/generated"
 	latest "github.com/devspace-cloud/devspace/pkg/devspace/config/versions/latest"
 	"github.com/devspace-cloud/devspace/pkg/devspace/kubectl"
 	"github.com/devspace-cloud/devspace/pkg/devspace/services"
@@ -74,12 +73,6 @@ func (cmd *EnterCmd) Run(cobraCmd *cobra.Command, args []string) {
 	// Get config
 	var config *latest.Config
 	if configutil.ConfigExists() {
-		// Load generated config
-		generatedConfig, err := generated.LoadConfig()
-		if err != nil {
-			log.Fatalf("Error loading generated.yaml: %v", err)
-		}
-
 		// Get config with adjusted cluster config
 		config, err := configutil.GetContextAdjustedConfig(cmd.Namespace, "", false)
 		if err != nil {
@@ -87,7 +80,7 @@ func (cmd *EnterCmd) Run(cobraCmd *cobra.Command, args []string) {
 		}
 
 		// Signal that we are working on the space if there is any
-		err = cloud.ResumeSpace(config, generatedConfig, true, log.GetInstance())
+		err = cloud.ResumeLatestSpace(config, true, log.GetInstance())
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/enter.go
+++ b/cmd/enter.go
@@ -81,7 +81,7 @@ func (cmd *EnterCmd) Run(cobraCmd *cobra.Command, args []string) {
 		}
 
 		// Get config with adjusted cluster config
-		config, err := configutil.GetContextAjustedConfig(cmd.Namespace, "")
+		config, err := configutil.GetContextAdjustedConfig(cmd.Namespace, "", false)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/enter.go
+++ b/cmd/enter.go
@@ -74,13 +74,19 @@ func (cmd *EnterCmd) Run(cobraCmd *cobra.Command, args []string) {
 	// Get config
 	var config *latest.Config
 	if configutil.ConfigExists() {
-		config = configutil.GetConfig()
-
+		// Load generated config
 		generatedConfig, err := generated.LoadConfig()
+		if err != nil {
+			log.Fatalf("Error loading generated.yaml: %v", err)
+		}
+
+		// Get config with adjusted cluster config
+		config, err := configutil.GetContextAjustedConfig(cmd.Namespace, "")
 		if err != nil {
 			log.Fatal(err)
 		}
 
+		// Signal that we are working on the space if there is any
 		err = cloud.ResumeSpace(config, generatedConfig, true, log.GetInstance())
 		if err != nil {
 			log.Fatal(err)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -205,7 +205,7 @@ func (cmd *InitCmd) Run(cobraCmd *cobra.Command, args []string) {
 			log.Fatal(err)
 		}
 
-		newImage, newDeployment, err = configure.GetDockerfileComponentDeployment(config, generatedConfig, deploymentName, "", cmd.Dockerfile, cmd.Context)
+		newImage, newDeployment, err = configure.GetDockerfileComponentDeployment(config, generatedConfig, deploymentName, "", cmd.Dockerfile, cmd.Context, true)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -482,13 +482,10 @@ func (cmd *InitCmd) addDevConfig() {
 		}
 	}
 
-	// Override image entrypoint
+	// Disable terminal by default
 	if len(*config.Images) > 0 {
-		config.Dev.OverrideImages = &[]*latest.ImageOverrideConfig{
-			&latest.ImageOverrideConfig{
-				Name:       ptr.String("default"),
-				Entrypoint: &[]*string{ptr.String("sleep"), ptr.String("999999999999")},
-			},
+		config.Dev.Terminal = &latest.Terminal{
+			Disabled: ptr.Bool(true),
 		}
 	}
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -437,29 +437,30 @@ func (cmd *InitCmd) addDevConfig() {
 		servicePort := (*(*config.Deployments)[0].Component.Service.Ports)[0]
 
 		if servicePort.Port != nil {
-			localPort := *servicePort.Port
-			var remotePort int
-			var err error
+			localPortPtr := servicePort.Port
+			var remotePortPtr *int
 
-			if localPort < 1024 {
-				log.Warn("Your application listens on a system port [0-1024]. Choose a forwarding-port to access your application via localhost.")
+			if *localPortPtr < 1024 {
+				log.WriteString("\n")
+				log.Warn("Your application listens on a system port [0-1024]. Choose a forwarding-port to access your application via localhost.\n")
 
 				portString := survey.Question(&survey.QuestionOptions{
 					Question:     "Which forwarding port [1024-49151] do you want to use to access your application?",
-					DefaultValue: strconv.Itoa(localPort + 8000),
+					DefaultValue: strconv.Itoa(*localPortPtr + 8000),
 				})
 
-				remotePort = localPort
+				remotePortPtr = localPortPtr
 
-				localPort, err = strconv.Atoi(portString)
+				localPort, err := strconv.Atoi(portString)
 				if err != nil {
 					log.Fatal("Error parsing port '%s'", portString)
 				}
+				localPortPtr = &localPort
 			}
 			portMappings := []*latest.PortMapping{}
 			portMappings = append(portMappings, &latest.PortMapping{
-				LocalPort:  &localPort,
-				RemotePort: &remotePort,
+				LocalPort:  localPortPtr,
+				RemotePort: remotePortPtr,
 			})
 
 			config.Dev.Ports = &[]*latest.PortForwardingConfig{

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -29,8 +29,8 @@ const configGitignore = "\n\n# Exclude .devspace generated files\n.devspace/\n"
 
 const (
 	// Cluster options
-	useDevSpaceCloud           = "DevSpace Cloud (managed cluster)"
-	useDevSpaceCloudOwnCluster = "DevSpace Cloud (connect your own cluster)"
+	useDevSpaceCloud           = "DevSpace Cloud (hosted Kubernetes namespaces, free)"
+	useDevSpaceCloudOwnCluster = "DevSpace Cloud (connect your cluster and create isolated namespaces)"
 	useCurrentContext          = "Use current kubectl context (no server-side component)"
 
 	// Cluster connect options

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -19,8 +19,9 @@ func NewInstallCmd() *cobra.Command {
 	cmd := &InstallCmd{}
 
 	installCmd := &cobra.Command{
-		Use:   "install",
-		Short: "Installs the DevSpace CLI",
+		Use:        "install",
+		Short:      "Installs the DevSpace CLI",
+		Deprecated: "devspace install is deprecated.",
 		Long: `
 #######################################################
 ################## devspace install ###################

--- a/cmd/list/deployments.go
+++ b/cmd/list/deployments.go
@@ -3,7 +3,6 @@ package list
 import (
 	"github.com/devspace-cloud/devspace/pkg/devspace/cloud"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/configutil"
-	"github.com/devspace-cloud/devspace/pkg/devspace/config/generated"
 	"github.com/devspace-cloud/devspace/pkg/devspace/deploy"
 	deployComponent "github.com/devspace-cloud/devspace/pkg/devspace/deploy/component"
 	deployHelm "github.com/devspace-cloud/devspace/pkg/devspace/deploy/helm"
@@ -52,15 +51,14 @@ func (cmd *deploymentsCmd) RunDeploymentsStatus(cobraCmd *cobra.Command, args []
 		"STATUS",
 	}
 
-	config := configutil.GetConfig()
-
-	generatedConfig, err := generated.LoadConfig()
+	// Get config with adjusted cluster config
+	config, err := configutil.GetContextAdjustedConfig("", "", false)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	// Signal that we are working on the space if there is any
-	err = cloud.ResumeSpace(config, generatedConfig, true, log.GetInstance())
+	err = cloud.ResumeLatestSpace(config, true, log.GetInstance())
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -69,9 +69,14 @@ func (cmd *LogsCmd) RunLogs(cobraCmd *cobra.Command, args []string) {
 
 	var config *latest.Config
 	if configutil.ConfigExists() {
-		config = configutil.GetConfig()
-
+		// Load generated config
 		generatedConfig, err := generated.LoadConfig()
+		if err != nil {
+			log.Fatalf("Error loading generated.yaml: %v", err)
+		}
+
+		// Get config with adjusted cluster config
+		config, err := configutil.GetContextAjustedConfig(cmd.Namespace, "")
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"github.com/devspace-cloud/devspace/pkg/devspace/cloud"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/configutil"
-	"github.com/devspace-cloud/devspace/pkg/devspace/config/generated"
 	latest "github.com/devspace-cloud/devspace/pkg/devspace/config/versions/latest"
 	"github.com/devspace-cloud/devspace/pkg/devspace/kubectl"
 	"github.com/devspace-cloud/devspace/pkg/devspace/services"
@@ -69,12 +68,6 @@ func (cmd *LogsCmd) RunLogs(cobraCmd *cobra.Command, args []string) {
 
 	var config *latest.Config
 	if configutil.ConfigExists() {
-		// Load generated config
-		generatedConfig, err := generated.LoadConfig()
-		if err != nil {
-			log.Fatalf("Error loading generated.yaml: %v", err)
-		}
-
 		// Get config with adjusted cluster config
 		config, err := configutil.GetContextAdjustedConfig(cmd.Namespace, "", false)
 		if err != nil {
@@ -82,7 +75,7 @@ func (cmd *LogsCmd) RunLogs(cobraCmd *cobra.Command, args []string) {
 		}
 
 		// Signal that we are working on the space if there is any
-		err = cloud.ResumeSpace(config, generatedConfig, true, log.GetInstance())
+		err = cloud.ResumeLatestSpace(config, true, log.GetInstance())
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -76,7 +76,7 @@ func (cmd *LogsCmd) RunLogs(cobraCmd *cobra.Command, args []string) {
 		}
 
 		// Get config with adjusted cluster config
-		config, err := configutil.GetContextAjustedConfig(cmd.Namespace, "")
+		config, err := configutil.GetContextAdjustedConfig(cmd.Namespace, "", false)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -140,15 +140,14 @@ func (cmd *OpenCmd) RunOpen(cobraCmd *cobra.Command, args []string) {
 	// Get default namespace
 	var devspaceConfig *latest.Config
 	if configExists {
-		devspaceConfig = configutil.GetConfig()
-
-		generatedConfig, err := generated.LoadConfig()
+		// Get config with adjusted cluster config
+		_, err := configutil.GetContextAdjustedConfig("", "", false)
 		if err != nil {
 			log.Fatal(err)
 		}
 
 		// Signal that we are working on the space if there is any
-		err = cloud.ResumeSpace(devspaceConfig, generatedConfig, true, log.GetInstance())
+		err = cloud.ResumeLatestSpace(devspaceConfig, true, log.GetInstance())
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -3,24 +3,30 @@ package cmd
 import (
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/devspace-cloud/devspace/pkg/devspace/analyze"
 	"github.com/devspace-cloud/devspace/pkg/devspace/cloud"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/configutil"
-	"github.com/devspace-cloud/devspace/pkg/devspace/config/generated"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/versions/latest"
 	"github.com/devspace-cloud/devspace/pkg/devspace/kubectl"
+	"github.com/devspace-cloud/devspace/pkg/devspace/services"
+
+	"github.com/devspace-cloud/devspace/pkg/util/kubeconfig"
 	"github.com/devspace-cloud/devspace/pkg/util/log"
+	"github.com/devspace-cloud/devspace/pkg/util/ptr"
 	"github.com/devspace-cloud/devspace/pkg/util/survey"
 
-	"github.com/mgutz/ansi"
 	"github.com/skratchdot/open-golang/open"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
+
+const openLocalHostOption = "via localhost (provides private access only on your computer via port-forwarding)"
+const openDomainOption = "via domain (makes your application publicly available via ingress)"
 
 // OpenCmd holds the open cmd flags
 type OpenCmd struct {
@@ -61,81 +67,15 @@ func (cmd *OpenCmd) RunOpen(cobraCmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	if configExists == false && len(args) == 0 {
-		log.Fatal("Please specify a space name or run this command in a devspace project")
-	}
 
-	// Get space name
 	var (
-		spaceName    = ""
 		providerName *string
+		provider     *cloud.Provider
+		spaceName    = ""
+		space        *cloud.Space
+		domain       string
+		tls          bool
 	)
-
-	if len(args) == 1 {
-		spaceName = args[0]
-	} else {
-		generatedConfig, err := generated.LoadConfig()
-		if err != nil {
-			log.Fatal(err)
-		}
-		if generatedConfig.CloudSpace == nil || generatedConfig.CloudSpace.Name == "" {
-			log.Fatalf("No space configured in project, please specify a space name or run: \n- `%s` to create a new space\n- `%s` to use an existing space", ansi.Color("devspace create space [NAME]", "white+b"), ansi.Color("devspace use space [NAME]", "white+b"))
-		}
-
-		spaceName = generatedConfig.CloudSpace.Name
-		providerName = &generatedConfig.CloudSpace.ProviderName
-	}
-
-	// Get provider
-	provider, err := cloud.GetProvider(providerName, log.GetInstance())
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	// Get space
-	space, err := provider.GetSpaceByName(spaceName)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	// Check if domain there is a domain for the space
-	if len(space.Domains) == 0 {
-		log.Fatalf("Space %s has no connected domain", space.Name)
-	}
-
-	// Select domain
-	domains := make([]string, 0, len(space.Domains))
-	for _, domain := range space.Domains {
-		domains = append(domains, domain.URL)
-	}
-
-	host := ""
-	if len(domains) == 1 {
-		host = domains[0]
-	} else {
-		host = survey.Question(&survey.QuestionOptions{
-			Question: "Please select a domain to open",
-			Options:  domains,
-		})
-	}
-
-	// If there is no config make sure the current kubectl context is correct
-	if configExists == false {
-		log.StartWait("Retrieve service account data")
-
-		// Change kube context
-		kubeContext := cloud.GetKubeContextNameFromSpace(space.Name, space.ProviderName)
-		serviceAccount, err := provider.GetServiceAccount(space)
-		if err != nil {
-			log.Fatalf("Error retrieving space service account: %v", err)
-		}
-		err = cloud.UpdateKubeConfig(kubeContext, serviceAccount, space.SpaceID, space.ProviderName, true)
-		if err != nil {
-			log.Fatalf("Error saving kube config: %v", err)
-		}
-
-		log.StopWait()
-	}
 
 	// Get default namespace
 	var devspaceConfig *latest.Config
@@ -163,22 +103,179 @@ func (cmd *OpenCmd) RunOpen(cobraCmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
-	// Check if domain exists
-	domain, tls, err := findDomain(client, namespace, host)
-	if err != nil {
-		log.Fatal(err)
-	}
+	currentContext, _, err := kubeconfig.GetCurrentContext()
 
-	// Not found
-	if domain == "" {
-		err = provider.CreateIngress(devspaceConfig, client, space, host)
-		if err != nil {
-			log.Fatalf("Error creating ingress: %v", err)
-		}
+	if len(args) == 1 {
+		spaceName = args[0]
 
-		domain, tls, err = findDomain(client, namespace, host)
+		// Get provider
+		provider, err = cloud.GetProvider(providerName, log.GetInstance())
 		if err != nil {
 			log.Fatal(err)
+		}
+
+		// Get space
+		space, err = provider.GetSpaceByName(spaceName)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// Update the current kubectl context to the one of the Space provided
+		log.StartWait("Retrieve service account data")
+
+		// Change kube context
+		kubeContext := cloud.GetKubeContextNameFromSpace(space.Name, space.ProviderName)
+		serviceAccount, err := provider.GetServiceAccount(space)
+		if err != nil {
+			log.Fatalf("Error retrieving space service account: %v", err)
+		}
+		err = cloud.UpdateKubeConfig(kubeContext, serviceAccount, space.SpaceID, space.ProviderName, true)
+		if err != nil {
+			log.Fatalf("Error saving kube config: %v", err)
+		}
+
+		log.StopWait()
+	} else {
+		spaceID, currentContextProvider, err := kubeconfig.GetSpaceID(currentContext)
+		if err == nil { // Current kube-context is a Space
+			if providerName == nil {
+				providerName = &currentContextProvider
+			}
+
+			// Get provider
+			provider, err = cloud.GetProvider(providerName, log.GetInstance())
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			// Get space
+			space, err = provider.GetSpace(spaceID)
+			if err != nil {
+				log.Fatal(err)
+			}
+		}
+	}
+
+	openingMode := survey.Question(&survey.QuestionOptions{
+		Question:     "How do you want to open your application?",
+		DefaultValue: openLocalHostOption,
+		Options: []string{
+			openLocalHostOption,
+			openDomainOption,
+		},
+	})
+
+	if openingMode == openLocalHostOption {
+		ports := []string{}
+
+		if devspaceConfig.Dev == nil {
+			devspaceConfig.Dev = &latest.DevConfig{}
+		}
+
+		if devspaceConfig.Dev.Ports == nil {
+			portConfigs := []*latest.PortForwardingConfig{}
+			devspaceConfig.Dev.Ports = &portConfigs
+		}
+		portConfigs := *devspaceConfig.Dev.Ports
+
+		// search for ports
+		for i := range portConfigs {
+			portMappings := *portConfigs[i].PortMappings
+
+			for ii := range portConfigs {
+				portMap := *portMappings[ii]
+
+				if portMap.LocalPort != nil {
+					ports = append(ports, strconv.Itoa(*portMap.LocalPort))
+				}
+			}
+		}
+		port := ""
+
+		// if no port is found, ask users which port and add it to config in-memory
+		if len(ports) == 0 {
+			port := survey.Question(&survey.QuestionOptions{
+				Question: "Which port does your application run on?",
+			})
+
+			intPort, err := strconv.Atoi(port)
+			if err != nil {
+				log.Fatal("Invalid port '%s': %v", port, err)
+			}
+
+			portMappings := []*latest.PortMapping{
+				&latest.PortMapping{
+					LocalPort: ptr.Int(intPort),
+				},
+			}
+
+			portConfigs = append(portConfigs, &latest.PortForwardingConfig{
+				PortMappings: &portMappings,
+			})
+		} else if len(ports) == 1 {
+			port = ports[0]
+		} else {
+			port = survey.Question(&survey.QuestionOptions{
+				Question: "Which port do you want to access?",
+				Options:  ports,
+			})
+		}
+		domain = "localhost:" + port
+
+		// start port-forwarding for localhost access
+		portForwarder, err := services.StartPortForwarding(devspaceConfig, client, log.GetInstance())
+		if err != nil {
+			log.Fatalf("Unable to start portforwarding: %v", err)
+		}
+
+		defer func() {
+			for _, v := range portForwarder {
+				v.Close()
+			}
+		}()
+	} else { // create ingress for public access via domain
+		if space != nil {
+			// Check if domain there is a domain for the space
+			if len(space.Domains) == 0 {
+				log.Fatalf("Space %s has no connected domain", space.Name)
+			}
+
+			// Select domain
+			domains := make([]string, 0, len(space.Domains))
+			for _, domain := range space.Domains {
+				domains = append(domains, domain.URL)
+			}
+
+			host := ""
+			if len(domains) == 1 {
+				host = domains[0]
+			} else {
+				host = survey.Question(&survey.QuestionOptions{
+					Question: "Please select a domain to open",
+					Options:  domains,
+				})
+			}
+
+			// Check if domain exists
+			domain, tls, err = findDomain(client, namespace, host)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			// Not found
+			if domain == "" {
+				err = provider.CreateIngress(devspaceConfig, client, space, host)
+				if err != nil {
+					log.Fatalf("Error creating ingress: %v", err)
+				}
+
+				domain, tls, err = findDomain(client, namespace, host)
+				if err != nil {
+					log.Fatal(err)
+				}
+			}
+		} else {
+			// TODO: create ingress for regular namespaces
 		}
 	}
 

--- a/cmd/purge.go
+++ b/cmd/purge.go
@@ -70,7 +70,7 @@ func (cmd *PurgeCmd) Run(cobraCmd *cobra.Command, args []string) {
 	}
 
 	// Get config with adjusted cluster config
-	config, err := configutil.GetContextAjustedConfig(cmd.Namespace, "")
+	config, err := configutil.GetContextAdjustedConfig(cmd.Namespace, "", false)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/purge.go
+++ b/cmd/purge.go
@@ -76,7 +76,7 @@ func (cmd *PurgeCmd) Run(cobraCmd *cobra.Command, args []string) {
 	}
 
 	// Signal that we are working on the space if there is any
-	err = cloud.ResumeSpace(config, generatedConfig, true, log.GetInstance())
+	err = cloud.ResumeLatestSpace(config, true, log.GetInstance())
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/remove/context.go
+++ b/cmd/remove/context.go
@@ -2,13 +2,16 @@ package remove
 
 import (
 	cloudpkg "github.com/devspace-cloud/devspace/pkg/devspace/cloud"
+	"github.com/devspace-cloud/devspace/pkg/util/kubeconfig"
 	"github.com/devspace-cloud/devspace/pkg/util/log"
+	"github.com/devspace-cloud/devspace/pkg/util/survey"
+	"github.com/mgutz/ansi"
 	"github.com/spf13/cobra"
 )
 
 type contextCmd struct {
-	All      bool
-	Provider string
+	AllSpaces bool
+	Provider  string
 }
 
 func newContextCmd() *cobra.Command {
@@ -16,23 +19,23 @@ func newContextCmd() *cobra.Command {
 
 	contextCmd := &cobra.Command{
 		Use:   "context",
-		Short: "Removes a cloud space kubectl context",
+		Short: "Removes a kubectl-context",
 		Long: `
 #######################################################
 ############# devspace remove context #################
 #######################################################
-Removes a cloud space kubectl context
+Removes a kubectl-context
 
 Example:
 devspace remove context myspace
-devspace remove context --all
+devspace remove context --all-spaces
 #######################################################
 	`,
 		Args: cobra.MaximumNArgs(1),
 		Run:  cmd.RunRemoveContext,
 	}
 
-	contextCmd.Flags().BoolVar(&cmd.All, "all", false, "Delete all kubectl contexts created from spaces")
+	contextCmd.Flags().BoolVar(&cmd.AllSpaces, "all-spaces", false, "Delete all kubectl contexts created from spaces")
 	contextCmd.Flags().StringVar(&cmd.Provider, "provider", "", "The cloud provider to use")
 
 	return contextCmd
@@ -53,7 +56,7 @@ func (cmd *contextCmd) RunRemoveContext(cobraCmd *cobra.Command, args []string) 
 	}
 
 	// Delete all contexts
-	if cmd.All {
+	if cmd.AllSpaces {
 		spaces, err := provider.GetSpaces()
 		if err != nil {
 			log.Fatal(err)
@@ -71,21 +74,68 @@ func (cmd *contextCmd) RunRemoveContext(cobraCmd *cobra.Command, args []string) 
 
 		log.Done("All space kubectl contexts removed")
 		return
-	} else if len(args) == 0 {
-		log.Fatal("Please specify a space name or the --all flag")
 	}
 
-	// Retrieve space
-	space, err := provider.GetSpaceByName(args[0])
+	// Load kube-config
+	kubeConfig, err := kubeconfig.LoadRawConfig()
 	if err != nil {
-		log.Fatalf("Error retrieving space %s: %v", args[0], err)
+		log.Fatalf("Unable to load kube-config: %v", err)
 	}
 
-	// Delete kube context
-	err = cloudpkg.DeleteKubeContext(space)
+	var contextName string
+
+	if len(args) > 0 {
+		// First arg is context name
+		contextName = args[0]
+	} else {
+		contexts := []string{}
+
+		for ctx, _ := range kubeConfig.Contexts {
+			contexts = append(contexts, ctx)
+		}
+
+		contextName = survey.Question(&survey.QuestionOptions{
+			Question: "Which context do you want to delete?",
+			Options:  contexts,
+		})
+	}
+
+	// Load kube-config
+	context, _, err := kubeconfig.GetContext(contextName)
 	if err != nil {
-		log.Fatalf("Error deleting kube context: %v", err)
+		log.Fatalf("Unable to load kube-config: %v", err)
 	}
 
-	log.Donef("Kubectl context deleted for space %s", args[0])
+	// Check if current kube-context blongs to Space
+	isSpace, err := kubeconfig.IsCloudSpace(context)
+	if err != nil {
+		log.Fatalf("Unable to check if context belongs to Space: %v", err)
+	}
+
+	if isSpace {
+		// Retrieve space
+		space, err := provider.GetSpaceByName(args[0])
+		if err != nil {
+			log.Fatalf("Error retrieving space %s: %v", args[0], err)
+		}
+
+		// Delete kube context
+		err = cloudpkg.DeleteKubeContext(space)
+		if err != nil {
+			log.Fatalf("Error deleting kube context: %v", err)
+		}
+	}
+
+	for ctx, _ := range kubeConfig.Contexts {
+		// Set first context as default for current kube-context
+		kubeConfig.CurrentContext = ctx
+		break
+	}
+
+	// Save updated kube-config
+	kubeconfig.SaveConfig(kubeConfig)
+
+	log.Infof("Your kube-context has been updated to '%s'", ansi.Color(kubeConfig.CurrentContext, "white+b"))
+
+	log.Donef("Kube-context '%s' has been successfully deleted", args[0])
 }

--- a/cmd/remove/context.go
+++ b/cmd/remove/context.go
@@ -106,9 +106,13 @@ func (cmd *contextCmd) RunRemoveContext(cobraCmd *cobra.Command, args []string) 
 		log.Fatalf("Unable to load kube-config: %v", err)
 	}
 
+	// Remove context
+	delete(kubeConfig.Contexts, contextName)
+
 	removeAuthInfo := true
 	removeCluster := true
 
+	// Check if AuthInfo or Cluster is used by any other context
 	for _, ctx := range kubeConfig.Contexts {
 		if ctx.AuthInfo == context.AuthInfo {
 			removeAuthInfo = false
@@ -119,15 +123,15 @@ func (cmd *contextCmd) RunRemoveContext(cobraCmd *cobra.Command, args []string) 
 		}
 	}
 
+	// Remove AuthInfo if not used by any other context
 	if removeAuthInfo {
 		delete(kubeConfig.AuthInfos, context.AuthInfo)
 	}
 
+	// Remove Cluster if not used by any other context
 	if removeCluster {
 		delete(kubeConfig.Clusters, context.Cluster)
 	}
-	
-	delete(kubeConfig.Contexts, contextName)
 
 	for ctx, _ := range kubeConfig.Contexts {
 		// Set first context as default for current kube-context

--- a/cmd/remove/context_test.go
+++ b/cmd/remove/context_test.go
@@ -220,8 +220,8 @@ func testRunRemoveContext(t *testing.T, testCase removeContextTestCase) {
 	}()
 
 	(&contextCmd{
-		Provider: testCase.provider,
-		All:      testCase.all,
+		Provider:  testCase.provider,
+		AllSpaces: testCase.all,
 	}).RunRemoveContext(nil, testCase.args)
 
 	assert.Equal(t, logOutput, testCase.expectedOutput, "Unexpected output in testCase %s", testCase.name)

--- a/cmd/remove/remove.go
+++ b/cmd/remove/remove.go
@@ -17,9 +17,10 @@ func NewRemoveCmd() *cobra.Command {
 		Args: cobra.NoArgs,
 	}
 
+	removeCmd.AddCommand(newClusterCmd())
+	removeCmd.AddCommand(newContextCmd())
 	removeCmd.AddCommand(newDeploymentCmd())
 	removeCmd.AddCommand(newImageCmd())
-	removeCmd.AddCommand(newClusterCmd())
 	removeCmd.AddCommand(newPortCmd())
 	removeCmd.AddCommand(newProviderCmd())
 	removeCmd.AddCommand(newSelectorCmd())

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -75,7 +75,7 @@ func (cmd *SyncCmd) Run(cobraCmd *cobra.Command, args []string) {
 		}
 
 		// Get config with adjusted cluster config
-		config, err := configutil.GetContextAjustedConfig(cmd.Namespace, "")
+		config, err := configutil.GetContextAdjustedConfig(cmd.Namespace, "", false)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -68,9 +68,14 @@ devspace sync --container-path=/my-path
 func (cmd *SyncCmd) Run(cobraCmd *cobra.Command, args []string) {
 	var config *latest.Config
 	if configutil.ConfigExists() {
-		config = configutil.GetConfig()
-
+		// Load generated config
 		generatedConfig, err := generated.LoadConfig()
+		if err != nil {
+			log.Fatalf("Error loading generated.yaml: %v", err)
+		}
+
+		// Get config with adjusted cluster config
+		config, err := configutil.GetContextAjustedConfig(cmd.Namespace, "")
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"github.com/devspace-cloud/devspace/pkg/devspace/cloud"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/configutil"
-	"github.com/devspace-cloud/devspace/pkg/devspace/config/generated"
 	latest "github.com/devspace-cloud/devspace/pkg/devspace/config/versions/latest"
 	"github.com/devspace-cloud/devspace/pkg/devspace/services"
 	"github.com/devspace-cloud/devspace/pkg/devspace/services/targetselector"
@@ -68,12 +67,6 @@ devspace sync --container-path=/my-path
 func (cmd *SyncCmd) Run(cobraCmd *cobra.Command, args []string) {
 	var config *latest.Config
 	if configutil.ConfigExists() {
-		// Load generated config
-		generatedConfig, err := generated.LoadConfig()
-		if err != nil {
-			log.Fatalf("Error loading generated.yaml: %v", err)
-		}
-
 		// Get config with adjusted cluster config
 		config, err := configutil.GetContextAdjustedConfig(cmd.Namespace, "", false)
 		if err != nil {
@@ -81,7 +74,7 @@ func (cmd *SyncCmd) Run(cobraCmd *cobra.Command, args []string) {
 		}
 
 		// Signal that we are working on the space if there is any
-		err = cloud.ResumeSpace(config, generatedConfig, true, log.GetInstance())
+		err = cloud.ResumeLatestSpace(config, true, log.GetInstance())
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/use/context.go
+++ b/cmd/use/context.go
@@ -1,0 +1,75 @@
+package use
+
+import (
+	"github.com/devspace-cloud/devspace/pkg/util/kubeconfig"
+	"github.com/devspace-cloud/devspace/pkg/util/log"
+	"github.com/devspace-cloud/devspace/pkg/util/survey"
+	"github.com/mgutz/ansi"
+	"github.com/spf13/cobra"
+)
+
+type contextCmd struct{}
+
+func newContextCmd() *cobra.Command {
+	cmd := &contextCmd{}
+
+	useContext := &cobra.Command{
+		Use:   "context",
+		Short: "Tells DevSpace which context to use",
+		Long: `
+#######################################################
+############### devspace use context ##################
+#######################################################
+Set the default context to deploy to
+
+Example:
+devspace use context my-context
+#######################################################
+	`,
+		Args: cobra.MaximumNArgs(1),
+		Run:  cmd.RunUseContext,
+	}
+
+	return useContext
+}
+
+// RunUseContext executes the functionality "devspace use namespace"
+func (cmd *contextCmd) RunUseContext(cobraCmd *cobra.Command, args []string) {
+	// Load kube-config
+	kubeConfig, err := kubeconfig.LoadRawConfig()
+	if err != nil {
+		log.Fatalf("Unable to load kube-config: %v", err)
+	}
+
+	var context string
+
+	if len(args) > 0 {
+		// First arg is context name
+		context = args[0]
+	} else {
+		contexts := []string{}
+
+		for ctx, _ := range kubeConfig.Contexts {
+			contexts = append(contexts, ctx)
+		}
+
+		context = survey.Question(&survey.QuestionOptions{
+			Question: "Which context do you want to use?",
+			Options:  contexts,
+		})
+	}
+	oldContext := kubeConfig.CurrentContext
+
+	// Set current kube-context
+	kubeConfig.CurrentContext = context
+
+	if oldContext != context {
+		// Save updated kube-config
+		kubeconfig.SaveConfig(kubeConfig)
+
+		log.Infof("Your kube-context has been updated to '%s'", ansi.Color(kubeConfig.CurrentContext, "white+b"))
+		log.Infof("\r          To revert this operation, run: %s\n", ansi.Color("devspace use context "+oldContext, "white+b"))
+	}
+
+	log.Donef("Successfully set kube-context to '%s'", ansi.Color(context, "white+b"))
+}

--- a/cmd/use/namespace.go
+++ b/cmd/use/namespace.go
@@ -22,7 +22,7 @@ func newNamespaceCmd() *cobra.Command {
 
 	useNamespace := &cobra.Command{
 		Use:   "namespace",
-		Short: "Tells DevSpace which namespace to deploy to",
+		Short: "Tells DevSpace which namespace to use",
 		Long: `
 #######################################################
 ############## devspace use namespace #################
@@ -116,7 +116,7 @@ func (cmd *namespaceCmd) RunUseNamespace(cobraCmd *cobra.Command, args []string)
 		kubeconfig.SaveConfig(kubeConfig)
 
 		log.Infof("The default namespace of your current kube-context '%s' has been updated to '%s'", ansi.Color(kubeConfig.CurrentContext, "white+b"), ansi.Color(namespace, "white+b"))
-		log.Infof("\r          To revert this operation, run: %s", ansi.Color("devspace use namespace "+oldDefaultNamespace, "white+b"))
+		log.Infof("\r          To revert this operation, run: %s\n", ansi.Color("devspace use namespace "+oldDefaultNamespace, "white+b"))
 	}
 
 	log.Donef("Successfully set default namespace to '%s'", ansi.Color(namespace, "white+b"))

--- a/cmd/use/namespace.go
+++ b/cmd/use/namespace.go
@@ -1,0 +1,81 @@
+package use
+
+import (
+	"github.com/devspace-cloud/devspace/pkg/devspace/config/configutil"
+	"github.com/devspace-cloud/devspace/pkg/devspace/config/generated"
+	"github.com/devspace-cloud/devspace/pkg/util/kubeconfig"
+	"github.com/devspace-cloud/devspace/pkg/util/log"
+	"github.com/mgutz/ansi"
+	"github.com/spf13/cobra"
+)
+
+type namespaceCmd struct{}
+
+func newNamespaceCmd() *cobra.Command {
+	cmd := &namespaceCmd{}
+
+	useNamespace := &cobra.Command{
+		Use:   "namespace",
+		Short: "Tells DevSpace which namespace to deploy to",
+		Long: `
+#######################################################
+################ devspace use space ###################
+#######################################################
+Set the default namesapce to deploy to
+
+Example:
+devspace use namespace my-space
+#######################################################
+	`,
+		Args: cobra.ExactArgs(1),
+		Run:  cmd.RunUseNamespace,
+	}
+
+	return useNamespace
+}
+
+// RunUseNamespace executes the functionality "devspace use namespace"
+func (cmd *namespaceCmd) RunUseNamespace(cobraCmd *cobra.Command, args []string) {
+	// Set config root
+	configExists, err := configutil.SetDevSpaceRoot()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if !configExists {
+		log.Fatal("Unable to find DevSpace config")
+	}
+
+	// First arg is namespace name
+	namespace := args[0]
+
+	// Get current kubectl context
+	kubeConfig, err := kubeconfig.LoadRawConfig()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Get generated config
+	generatedConfig, err := generated.LoadConfig()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Make sure DevSpace is not using a space anymore
+	generatedConfig.CloudSpace = nil
+
+	// Configure DevSpace to use plain namespace
+	generatedConfig.Namespace = &generated.NamespaceConfig{
+		Name:        &namespace,
+		KubeContext: &kubeConfig.CurrentContext,
+	}
+
+	// Save generated config
+	err = generated.SaveConfig(generatedConfig)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Donef("Successfully configured DevSpace to use namespace %s", namespace)
+	log.Infof("\r          \nRun:\n- `%s` to develop application\n- `%s` to deploy application\n", ansi.Color("devspace dev", "white+b"), ansi.Color("devspace deploy", "white+b"))
+}

--- a/cmd/use/namespace.go
+++ b/cmd/use/namespace.go
@@ -61,7 +61,7 @@ func (cmd *namespaceCmd) RunUseNamespace(cobraCmd *cobra.Command, args []string)
 	}
 
 	// Check if current kube-context blongs to Space
-	isSpace, err := kubeconfig.ContextIsCloudSpace(currentContext)
+	isSpace, err := kubeconfig.IsCloudSpace(currentContext)
 	if err != nil {
 		log.Fatalf("Unable to check if context belongs to Space: %v", err)
 	}

--- a/cmd/use/namespace.go
+++ b/cmd/use/namespace.go
@@ -1,6 +1,8 @@
 package use
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/configutil"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/generated"
 	"github.com/devspace-cloud/devspace/pkg/util/kubeconfig"
@@ -9,7 +11,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type namespaceCmd struct{}
+type namespaceCmd struct {
+	Reset bool
+}
 
 func newNamespaceCmd() *cobra.Command {
 	cmd := &namespaceCmd{}
@@ -19,17 +23,19 @@ func newNamespaceCmd() *cobra.Command {
 		Short: "Tells DevSpace which namespace to deploy to",
 		Long: `
 #######################################################
-################ devspace use space ###################
+############## devspace use namespace #################
 #######################################################
-Set the default namesapce to deploy to
+Set the default namespace to deploy to
 
 Example:
-devspace use namespace my-space
+devspace use namespace my-namespace
 #######################################################
 	`,
-		Args: cobra.ExactArgs(1),
+		Args: cobra.MaximumNArgs(1),
 		Run:  cmd.RunUseNamespace,
 	}
+
+	useNamespace.Flags().BoolVar(&cmd.Reset, "reset", false, "Resets the default namespace of the current kube-context")
 
 	return useNamespace
 }
@@ -42,40 +48,73 @@ func (cmd *namespaceCmd) RunUseNamespace(cobraCmd *cobra.Command, args []string)
 		log.Fatal(err)
 	}
 
-	if !configExists {
-		log.Fatal("Unable to find DevSpace config")
-	}
-
-	// First arg is namespace name
-	namespace := args[0]
-
-	// Get current kubectl context
+	// Load kube-config
 	kubeConfig, err := kubeconfig.LoadRawConfig()
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("Unable to load kube-config: %v", err)
 	}
 
-	// Get generated config
-	generatedConfig, err := generated.LoadConfig()
+	// Get current kube-context
+	currentContext, ok := kubeConfig.Contexts[kubeConfig.CurrentContext]
+	if !ok {
+		log.Fatalf("Unable to find current kube-context '%s' in kube-config file", kubeConfig.CurrentContext)
+	}
+
+	// Check if current kube-context blongs to Space
+	isSpace, err := kubeconfig.ContextIsCloudSpace(currentContext)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("Unable to check if context belongs to Space: %v", err)
 	}
 
-	// Make sure DevSpace is not using a space anymore
-	generatedConfig.CloudSpace = nil
-
-	// Configure DevSpace to use plain namespace
-	generatedConfig.Namespace = &generated.NamespaceConfig{
-		Name:        &namespace,
-		KubeContext: &kubeConfig.CurrentContext,
+	if isSpace {
+		log.Fatalf("Current kube-context belongs to a Space created by DevSpace Cloud. Changing the default namespace for a Space context is not possible.")
 	}
 
-	// Save generated config
-	err = generated.SaveConfig(generatedConfig)
-	if err != nil {
-		log.Fatal(err)
+	// Remember current default namespace
+	oldDefaultNamespace := currentContext.Namespace
+
+	namespace := ""
+
+	if len(args) > 0 {
+		// First arg is namespace name
+		namespace := args[0]
+
+		if namespace == metav1.NamespaceDefault {
+			log.Warn("Using the 'default' namespace of your cluster is highly discouraged as this namespace cannot be deleted.")
+		}
+	} else if !cmd.Reset {
+		// TODO: Show picker
 	}
 
-	log.Donef("Successfully configured DevSpace to use namespace %s", namespace)
-	log.Infof("\r          \nRun:\n- `%s` to develop application\n- `%s` to deploy application\n", ansi.Color("devspace dev", "white+b"), ansi.Color("devspace deploy", "white+b"))
+	// Set namespace as default for current kube-context
+	currentContext.Namespace = namespace
+
+	if oldDefaultNamespace != namespace {
+		// Save updated kube-config
+		kubeconfig.SaveConfig(kubeConfig)
+
+		log.Infof("The default namespace of your current kube-context '%s' has been updated to '%s'", ansi.Color(kubeConfig.CurrentContext, "white+b"), ansi.Color(namespace, "white+b"))
+		log.Infof("\r          To revert this operation, run: %s", ansi.Color("devspace use namespace "+oldDefaultNamespace, "white+b"))
+	}
+
+	log.Donef("Successfully set default namespace to '%s'", ansi.Color(namespace, "white+b"))
+
+	if configExists {
+		// Get generated config
+		generatedConfig, err := generated.LoadConfig()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// Reset namespace cache
+		generatedConfig.Namespace = nil
+
+		// Save generated config
+		err = generated.SaveConfig(generatedConfig)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		log.Infof("\r          \nRun:\n- `%s` to develop application\n- `%s` to deploy application\n", ansi.Color("devspace dev", "white+b"), ansi.Color("devspace deploy", "white+b"))
+	}
 }

--- a/cmd/use/space.go
+++ b/cmd/use/space.go
@@ -34,7 +34,6 @@ Use an existing space for the current configuration
 
 Example:
 devspace use space my-space
-devspace use space none    // stop using a space
 #######################################################
 	`,
 		Args: cobra.MaximumNArgs(1),
@@ -54,36 +53,6 @@ func (cmd *spaceCmd) RunUseSpace(cobraCmd *cobra.Command, args []string) {
 	configExists, err := configutil.SetDevSpaceRoot()
 	if err != nil {
 		log.Fatal(err)
-	}
-
-	// Erase currently used space
-	if len(args) > 0 && args[0] == "none" {
-		// Set tiller env
-		err = cloudpkg.SetTillerNamespace(nil)
-		if err != nil {
-			// log.Warnf("Couldn't set tiller namespace environment variable: %v", err)
-		}
-
-		if !configExists {
-			return
-		}
-
-		// Get generated config
-		generatedConfig, err := generated.LoadConfig()
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		generatedConfig.CloudSpace = nil
-		generatedConfig.Configs = map[string]*generated.CacheConfig{}
-
-		err = generated.SaveConfig(generatedConfig)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		log.Info("Successfully erased space from config")
-		return
 	}
 
 	// Check if user has specified a certain provider

--- a/cmd/use/space.go
+++ b/cmd/use/space.go
@@ -80,7 +80,7 @@ func (cmd *spaceCmd) RunUseSpace(cobraCmd *cobra.Command, args []string) {
 		if err != nil {
 			log.Fatalf("Error retrieving spaces: %v", err)
 		} else if len(spaces) == 0 {
-			log.Fatalf("There are no spaces to select from. Please create a space with `%s`", ansi.Color("devspace create space [NAME]", "white+b"))
+			log.Fatalf("You do not have any Spaces, yet. You can create a space with `%s`", ansi.Color("devspace create space [NAME]", "white+b"))
 		}
 
 		names := make([]string, 0, len(spaces))
@@ -89,7 +89,7 @@ func (cmd *spaceCmd) RunUseSpace(cobraCmd *cobra.Command, args []string) {
 		}
 
 		spaceName := survey.Question(&survey.QuestionOptions{
-			Question: "Please select a space that you want to use",
+			Question: "Please select the Space that you want to use",
 			Options:  names,
 		})
 

--- a/cmd/use/space.go
+++ b/cmd/use/space.go
@@ -6,7 +6,6 @@ import (
 	"github.com/devspace-cloud/devspace/pkg/devspace/cloud"
 	cloudpkg "github.com/devspace-cloud/devspace/pkg/devspace/cloud"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/configutil"
-	"github.com/devspace-cloud/devspace/pkg/devspace/config/generated"
 	"github.com/devspace-cloud/devspace/pkg/util/log"
 	"github.com/devspace-cloud/devspace/pkg/util/survey"
 	"github.com/mgutz/ansi"
@@ -163,20 +162,8 @@ func (cmd *spaceCmd) RunUseSpace(cobraCmd *cobra.Command, args []string) {
 	}
 
 	if configExists {
-		// Get generated config
-		generatedConfig, err := generated.LoadConfig()
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		// Cache space
-		err = provider.CacheSpace(generatedConfig, space)
-		if err != nil {
-			log.Fatal(err)
-		}
-
 		// Signal that we are working on the space if there is any
-		err = cloud.ResumeSpace(configutil.GetConfig(), generatedConfig, false, log.GetInstance())
+		err = cloud.ResumeSpace(configutil.GetConfig(), space.ProviderName, space.SpaceID, false, log.GetInstance())
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/use/space.go
+++ b/cmd/use/space.go
@@ -48,7 +48,7 @@ devspace use space none    // stop using a space
 	return useSpace
 }
 
-// RunUseDevSpace executes the functionality "devspace use space"
+// RunUseSpace executes the functionality "devspace use space"
 func (cmd *spaceCmd) RunUseSpace(cobraCmd *cobra.Command, args []string) {
 	// Set config root
 	configExists, err := configutil.SetDevSpaceRoot()
@@ -213,5 +213,5 @@ func (cmd *spaceCmd) RunUseSpace(cobraCmd *cobra.Command, args []string) {
 		}
 	}
 
-	log.Donef("Successfully configured config to use space %s", space.Name)
+	log.Donef("Successfully configured DevSpace to use space %s", space.Name)
 }

--- a/cmd/use/use.go
+++ b/cmd/use/use.go
@@ -18,9 +18,10 @@ func NewUseCmd() *cobra.Command {
 	}
 
 	useCmd.AddCommand(newConfigCmd())
-	useCmd.AddCommand(newSpaceCmd())
+	useCmd.AddCommand(newContextCmd())
 	useCmd.AddCommand(newNamespaceCmd())
 	useCmd.AddCommand(newProviderCmd())
+	useCmd.AddCommand(newSpaceCmd())
 
 	return useCmd
 }

--- a/cmd/use/use.go
+++ b/cmd/use/use.go
@@ -19,6 +19,7 @@ func NewUseCmd() *cobra.Command {
 
 	useCmd.AddCommand(newConfigCmd())
 	useCmd.AddCommand(newSpaceCmd())
+	useCmd.AddCommand(newNamespaceCmd())
 	useCmd.AddCommand(newProviderCmd())
 
 	return useCmd

--- a/docs/devspace.yaml
+++ b/docs/devspace.yaml
@@ -12,11 +12,8 @@ deployments:
       ports:
       - port: 3000
 dev:
-  overrideImages:
-  - name: default
-    entrypoint:
-    - sleep
-    - "999999999999"
+  terminal:
+    disabled: true
   ports:
   - labelSelector:
       app.kubernetes.io/component: docs

--- a/go.mod
+++ b/go.mod
@@ -68,7 +68,7 @@ require (
 	github.com/spf13/cast v1.3.0 // indirect
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/jwalterweatherman v1.0.0 // indirect
-	github.com/spf13/pflag v1.0.3 // indirect
+	github.com/spf13/pflag v1.0.3
 	github.com/spf13/viper v1.0.2
 	github.com/tcnksm/go-gitconfig v0.1.2 // indirect
 	github.com/theupdateframework/notary v0.6.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/docker/go v1.5.1-1 // indirect
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-metrics v0.0.0-20180209012529-399ea8c73916 // indirect
-	github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c // indirect
+	github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c
 	github.com/evanphx/json-patch v4.1.0+incompatible // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
@@ -91,6 +91,7 @@ require (
 	k8s.io/apimachinery v0.0.0
 	k8s.io/client-go v0.0.0
 	k8s.io/helm v2.14.2+incompatible
+	k8s.io/klog v0.3.1
 	k8s.io/kubernetes v1.15.0
 	vbom.ml/util v0.0.0-20180919145318-efcd4e0f9787 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -128,6 +128,7 @@ github.com/evanphx/json-patch v4.1.0+incompatible h1:K1MDoo4AZ4wU0GIU/fPmtZg7Vpz
 github.com/evanphx/json-patch v4.1.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d h1:105gxyaGwCFad8crR9dcMQWvV9Hvulu6hwUh4tWPJnM=
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZMPRZwes7CROmyNKgQzC3XPs6L/G2EJLHddWejkmf4=
+github.com/fatih/camelcase v0.0.0-20160318181535-f6a740d52f96 h1:5e8GDOdG6jKeeqNGbR+tlmqhf4vQVs3atTTMEWeEcAk=
 github.com/fatih/camelcase v0.0.0-20160318181535-f6a740d52f96/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
@@ -289,9 +290,11 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxv
 github.com/kr/fs v0.0.0-20131111012553-2788f0dbd169 h1:YUrU1/jxRqnt0PSrKj1Uj/wEjk/fjnE80QFfi2Zlj7Q=
 github.com/kr/fs v0.0.0-20131111012553-2788f0dbd169/go.mod h1:glhvuHOU9Hy7/8PwwdtnarXqLagOX0b/TbZx2zLMqEg=
 github.com/kr/pretty v0.0.0-20140812000539-f31442d60e51/go.mod h1:Bvhd+E3laJ0AVkG0c9rmtZcnhV0HQ3+c3YxxqTvc/gA=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.0.0-20130911015532-6807e777504f/go.mod h1:sjUstKUATFIcff4qlB53Kml0wQPtJVc/3fWrmuUmcfA=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.1.1 h1:sJZmqHoEaY7f+NPP8pgLB/WxulyR3fewgCM2qaSlBb4=
@@ -592,6 +595,7 @@ gopkg.in/AlecAivazis/survey.v1 v1.8.2/go.mod h1:iBNOmqKz/NUbZx3bA+4hAGLRC7fSK7tg
 gopkg.in/AlecAivazis/survey.v1 v1.8.4 h1:10xXXN3wgIhPheb5NI58zFgZv32Ana7P3Tl4shW+0Qc=
 gopkg.in/AlecAivazis/survey.v1 v1.8.4/go.mod h1:iBNOmqKz/NUbZx3bA+4hAGLRC7fSK7tgtVDT4tB22XA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/gcfg.v1 v1.2.0/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=

--- a/pkg/devspace/cloud/configure.go
+++ b/pkg/devspace/cloud/configure.go
@@ -90,7 +90,7 @@ func UpdateKubeConfig(contextName string, serviceAccount *ServiceAccount, spaceI
 	authInfo := api.NewAuthInfo()
 	authInfo.Exec = &api.ExecConfig{
 		APIVersion: "client.authentication.k8s.io/v1alpha1",
-		Command:    "devspace",
+		Command:    kubeconfig.AuthCommand,
 		Args:       []string{"use", "space", "--provider", providerName, "--space-id", strconv.Itoa(spaceID), "--get-token"},
 	}
 

--- a/pkg/devspace/cloud/resume.go
+++ b/pkg/devspace/cloud/resume.go
@@ -25,6 +25,10 @@ func ResumeLatestSpace(config *latest.Config, loop bool, log log.Logger) error {
 
 	if generatedConfig != nil && generatedConfig.Namespace != nil && generatedConfig.Namespace.KubeContext != nil {
 		context, contextName, err := kubeconfig.GetContext(*generatedConfig.Namespace.KubeContext)
+		if err != nil {
+			return fmt.Errorf("Unable to get current kube-context: %v", err)
+		}
+
 		spaceID, cloudProvider, err := kubeconfig.GetSpaceID(context)
 		if err != nil {
 			return fmt.Errorf("Unable to get Space ID for context %s: %v", contextName, err)

--- a/pkg/devspace/cloud/util.go
+++ b/pkg/devspace/cloud/util.go
@@ -11,46 +11,12 @@ import (
 	"time"
 
 	"github.com/devspace-cloud/devspace/pkg/devspace/cloud/token"
-	"github.com/devspace-cloud/devspace/pkg/devspace/config/generated"
-	"github.com/devspace-cloud/devspace/pkg/devspace/config/versions/util"
 	"github.com/pkg/errors"
 
 	"github.com/devspace-cloud/devspace/pkg/util/envutil"
 	"github.com/devspace-cloud/devspace/pkg/util/kubeconfig"
 	"github.com/devspace-cloud/devspace/pkg/util/log"
 )
-
-// CacheSpace converts the space config into a cloud space config
-func (p *Provider) CacheSpace(generatedConfig *generated.Config, space *Space) error {
-	// Remove namespace from generated config as user wants to use space instead of plain namespace
-	generatedConfig.Namespace = nil
-
-	// Convert space domains
-	var domains []*generated.CloudSpaceDomainConfig
-	if space.Domains != nil && len(space.Domains) > 0 {
-		domains = make([]*generated.CloudSpaceDomainConfig, 0, len(space.Domains))
-
-		err := util.Convert(space.Domains, &domains)
-		if err != nil {
-			return err
-		}
-	}
-
-	generatedConfig.CloudSpace = &generated.CloudSpaceConfig{
-		SpaceID:      space.SpaceID,
-		ProviderName: space.ProviderName,
-		Name:         space.Name,
-		Namespace:    space.Namespace,
-		Owner:        space.Owner.Name,
-		OwnerID:      space.Owner.OwnerID,
-		KubeContext:  GetKubeContextNameFromSpace(space.Name, space.ProviderName),
-		Domains:      domains,
-		Created:      space.Created,
-	}
-
-	generatedConfig.Configs = map[string]*generated.CacheConfig{}
-	return generated.SaveConfig(generatedConfig)
-}
 
 // PrintSpaces prints the users spaces
 func (p *Provider) PrintSpaces(cluster, name string, all bool) error {

--- a/pkg/devspace/cloud/util.go
+++ b/pkg/devspace/cloud/util.go
@@ -11,12 +11,12 @@ import (
 	"time"
 
 	"github.com/devspace-cloud/devspace/pkg/devspace/cloud/token"
-	"github.com/devspace-cloud/devspace/pkg/devspace/config/configutil"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/generated"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/versions/util"
 	"github.com/pkg/errors"
 
 	"github.com/devspace-cloud/devspace/pkg/util/envutil"
+	"github.com/devspace-cloud/devspace/pkg/util/kubeconfig"
 	"github.com/devspace-cloud/devspace/pkg/util/log"
 )
 
@@ -60,11 +60,9 @@ func (p *Provider) PrintSpaces(cluster, name string, all bool) error {
 	}
 
 	activeSpaceID := 0
-	if configutil.ConfigExists() {
-		generated, err := generated.LoadConfig()
-		if err == nil && generated.CloudSpace != nil {
-			activeSpaceID = generated.CloudSpace.SpaceID
-		}
+	currentContext, _, err := kubeconfig.GetCurrentContext()
+	if err == nil {
+		activeSpaceID, _, _ = kubeconfig.GetSpaceID(currentContext)
 	}
 
 	headerColumnNames := []string{}

--- a/pkg/devspace/cloud/util.go
+++ b/pkg/devspace/cloud/util.go
@@ -22,6 +22,9 @@ import (
 
 // CacheSpace converts the space config into a cloud space config
 func (p *Provider) CacheSpace(generatedConfig *generated.Config, space *Space) error {
+	// Remove namespace from generated config as user wants to use space instead of plain namespace
+	generatedConfig.Namespace = nil
+
 	// Convert space domains
 	var domains []*generated.CloudSpaceDomainConfig
 	if space.Domains != nil && len(space.Domains) > 0 {

--- a/pkg/devspace/config/configutil/get.go
+++ b/pkg/devspace/config/configutil/get.go
@@ -228,21 +228,6 @@ func loadBaseConfigFromPath(basePath string, loadConfig string, loadOverwrites b
 		} else {
 			log.Infof("Loaded config from %s", constants.DefaultConfigPath)
 		}
-
-		// Exchange kube context if necessary, but only if we don't load the base config
-		// we do this to avoid saving the kube context on commands like
-		// devspace add deployment && devspace add image etc.
-		if generatedConfig.CloudSpace != nil {
-			if config.Cluster == nil || config.Cluster.KubeContext == nil {
-				if generatedConfig.CloudSpace.KubeContext == "" {
-					return nil, nil, fmt.Errorf("No space configured!\n\nPlease run: \n- `%s` to create a new space\n- `%s` to use an existing space\n- `%s` to list existing spaces", ansi.Color("devspace create space [NAME]", "white+b"), ansi.Color("devspace use space [NAME]", "white+b"), ansi.Color("devspace list spaces", "white+b"))
-				}
-
-				config.Cluster = &latest.Cluster{
-					KubeContext: &generatedConfig.CloudSpace.KubeContext,
-				}
-			}
-		}
 	} else {
 		if configDefinition != nil {
 			log.Infof("Loaded config %s from %s", loadConfig, constants.DefaultConfigsPath)

--- a/pkg/devspace/config/configutil/load.go
+++ b/pkg/devspace/config/configutil/load.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/devspace-cloud/devspace/pkg/util/git"
+	"github.com/devspace-cloud/devspace/pkg/util/kubeconfig"
 	"github.com/devspace-cloud/devspace/pkg/util/ptr"
 	"github.com/devspace-cloud/devspace/pkg/util/randutil"
 	"github.com/devspace-cloud/devspace/pkg/util/survey"
@@ -65,21 +66,31 @@ var PredefinedVars = map[string]*predefinedVarDefinition{
 	"DEVSPACE_SPACE": &predefinedVarDefinition{
 		ErrorMessage: fmt.Sprintf("No space configured, but predefined var DEVSPACE_SPACE is used.\n\nPlease run: \n- `%s` to create a new space\n- `%s` to use an existing space\n- `%s` to list existing spaces", ansi.Color("devspace create space [NAME]", "white+b"), ansi.Color("devspace use space [NAME]", "white+b"), ansi.Color("devspace list spaces", "white+b")),
 		Fill: func(generatedConfig *generated.Config) (*string, error) {
-			if generatedConfig.CloudSpace != nil {
-				if generatedConfig.CloudSpace.Name != "" {
-					return &generatedConfig.CloudSpace.Name, nil
-				}
+			context, contextName, err := kubeconfig.GetCurrentContext()
+			if err != nil {
+				return nil, err
 			}
 
+			isSpace, err := kubeconfig.IsCloudSpace(context)
+			if err != nil {
+				return nil, err
+			}
+
+			contextNameSplit := strings.Split(contextName, "-")
+
+			if isSpace && len(contextNameSplit) > 1 {
+				spaceName := strings.Join(contextNameSplit[1:], "-")
+				return &spaceName, nil
+			}
 			return nil, nil
 		},
 	},
 	"DEVSPACE_SPACE_NAMESPACE": &predefinedVarDefinition{
 		ErrorMessage: fmt.Sprintf("No space configured, but predefined var DEVSPACE_SPACE_NAMESPACE is used.\n\nPlease run: \n- `%s` to create a new space\n- `%s` to use an existing space\n- `%s` to list existing spaces", ansi.Color("devspace create space [NAME]", "white+b"), ansi.Color("devspace use space [NAME]", "white+b"), ansi.Color("devspace list spaces", "white+b")),
 		Fill: func(generatedConfig *generated.Config) (*string, error) {
-			if generatedConfig.CloudSpace != nil {
-				if generatedConfig.CloudSpace.Namespace != "" {
-					return &generatedConfig.CloudSpace.Namespace, nil
+			if generatedConfig.Namespace != nil {
+				if generatedConfig.Namespace.Name != nil {
+					return generatedConfig.Namespace.Name, nil
 				}
 			}
 
@@ -89,11 +100,15 @@ var PredefinedVars = map[string]*predefinedVarDefinition{
 	"DEVSPACE_USERNAME": &predefinedVarDefinition{
 		ErrorMessage: fmt.Sprintf("Not logged into Devspace Cloud, but predefined var DEVSPACE_USERNAME is used.\n\nPlease run: \n- `%s` to login into devspace cloud. Alternatively you can also remove the variable ${DEVSPACE_USERNAME} from your config", ansi.Color("devspace login", "white+b")),
 		Fill: func(generatedConfig *generated.Config) (*string, error) {
-			providerName := cloudconfig.DevSpaceCloudProviderName
-			if generatedConfig.CloudSpace != nil {
-				if generatedConfig.CloudSpace.ProviderName != "" {
-					providerName = generatedConfig.CloudSpace.ProviderName
-				}
+			context, _, err := kubeconfig.GetCurrentContext()
+			if err != nil {
+				return nil, err
+			}
+
+			_, providerName, err := kubeconfig.GetSpaceID(context)
+			if err != nil {
+				// use global provider config as fallback
+				providerName = cloudconfig.DevSpaceCloudProviderName
 			}
 
 			cloudConfigData, err := cloudconfig.ParseProviderConfig()
@@ -136,18 +151,20 @@ func getPredefinedVar(name string, generatedConfig *generated.Config) (bool, str
 
 	// Load space domain environment variable
 	if strings.HasPrefix(strings.ToUpper(name), "DEVSPACE_SPACE_DOMAIN") {
+		/* TODO @FabianKramm
 		idx, err := strconv.Atoi(name[len("DEVSPACE_SPACE_DOMAIN"):])
 		if err != nil {
 			return false, "", fmt.Errorf("Error parsing variable %s: %v", name, err)
 		}
 
+		
 		if generatedConfig.CloudSpace == nil {
 			return false, "", fmt.Errorf("No space configured, but predefined var %s is used.\n\nPlease run: \n- `%s` to create a new space\n- `%s` to use an existing space\n- `%s` to list existing spaces", name, ansi.Color("devspace create space [NAME]", "white+b"), ansi.Color("devspace use space [NAME]", "white+b"), ansi.Color("devspace list spaces", "white+b"))
 		} else if len(generatedConfig.CloudSpace.Domains) <= idx-1 {
 			return false, "", fmt.Errorf("Error loading %s: Space has %d domains but domain with number %d was requested", name, len(generatedConfig.CloudSpace.Domains), idx)
 		}
 
-		return true, generatedConfig.CloudSpace.Domains[idx-1].URL, nil
+		return true, generatedConfig.CloudSpace.Domains[idx-1].URL, nil*/
 	}
 
 	return false, "", nil

--- a/pkg/devspace/config/configutil/load.go
+++ b/pkg/devspace/config/configutil/load.go
@@ -68,12 +68,12 @@ var PredefinedVars = map[string]*predefinedVarDefinition{
 		Fill: func(generatedConfig *generated.Config) (*string, error) {
 			context, contextName, err := kubeconfig.GetCurrentContext()
 			if err != nil {
-				return nil, err
+				return nil, nil
 			}
 
 			isSpace, err := kubeconfig.IsCloudSpace(context)
 			if err != nil {
-				return nil, err
+				return nil, nil
 			}
 
 			contextNameSplit := strings.Split(contextName, "-")
@@ -102,7 +102,7 @@ var PredefinedVars = map[string]*predefinedVarDefinition{
 		Fill: func(generatedConfig *generated.Config) (*string, error) {
 			context, _, err := kubeconfig.GetCurrentContext()
 			if err != nil {
-				return nil, err
+				return nil, nil
 			}
 
 			_, providerName, err := kubeconfig.GetSpaceID(context)
@@ -157,7 +157,7 @@ func getPredefinedVar(name string, generatedConfig *generated.Config) (bool, str
 			return false, "", fmt.Errorf("Error parsing variable %s: %v", name, err)
 		}
 
-		
+
 		if generatedConfig.CloudSpace == nil {
 			return false, "", fmt.Errorf("No space configured, but predefined var %s is used.\n\nPlease run: \n- `%s` to create a new space\n- `%s` to use an existing space\n- `%s` to list existing spaces", name, ansi.Color("devspace create space [NAME]", "white+b"), ansi.Color("devspace use space [NAME]", "white+b"), ansi.Color("devspace list spaces", "white+b"))
 		} else if len(generatedConfig.CloudSpace.Domains) <= idx-1 {

--- a/pkg/devspace/config/generated/config.go
+++ b/pkg/devspace/config/generated/config.go
@@ -16,33 +16,13 @@ const DefaultConfigName = "default"
 type Config struct {
 	ActiveConfig string                  `yaml:"activeConfig,omitempty"`
 	Configs      map[string]*CacheConfig `yaml:"configs,omitempty"`
-	CloudSpace   *CloudSpaceConfig       `yaml:"space,omitempty"`
 	Namespace    *NamespaceConfig        `yaml:"namespace,omitempty"`
 }
 
 // NamespaceConfig holds all the informations about the namespace to use
 type NamespaceConfig struct {
-	Name    *string `yaml:"name,omitempty"`
+	Name        *string `yaml:"name,omitempty"`
 	KubeContext *string `yaml:"context,omitempty"`
-}
-
-// CloudSpaceConfig holds all the informations about a certain cloud space
-type CloudSpaceConfig struct {
-	SpaceID      int                       `yaml:"spaceID,omitempty"`
-	OwnerID      int                       `yaml:"ownerID,omitempty"`
-	Owner        string                    `yaml:"owner,omitempty"`
-	ProviderName string                    `yaml:"providerName,omitempty"`
-	KubeContext  string                    `yaml:"kubeContext,omitempty"`
-	Namespace    string                    `yaml:"namespace,omitempty"`
-	Name         string                    `yaml:"name,omitempty"`
-	Domains      []*CloudSpaceDomainConfig `yaml:"domains,omitempty"`
-	Created      string                    `yaml:"created,omitempty"`
-}
-
-// CloudSpaceDomainConfig holds the space domain related information
-type CloudSpaceDomainConfig struct {
-	DomainID int    `yaml:"id,omitempty"`
-	URL      string `yaml:"url,omitempty"`
 }
 
 // CacheConfig holds all the information specific to a certain config

--- a/pkg/devspace/config/generated/config.go
+++ b/pkg/devspace/config/generated/config.go
@@ -17,6 +17,13 @@ type Config struct {
 	ActiveConfig string                  `yaml:"activeConfig,omitempty"`
 	Configs      map[string]*CacheConfig `yaml:"configs,omitempty"`
 	CloudSpace   *CloudSpaceConfig       `yaml:"space,omitempty"`
+	Namespace    *NamespaceConfig        `yaml:"namespace,omitempty"`
+}
+
+// NamespaceConfig holds all the informations about the namespace to use
+type NamespaceConfig struct {
+	Name    *string `yaml:"name,omitempty"`
+	KubeContext *string `yaml:"context,omitempty"`
 }
 
 // CloudSpaceConfig holds all the informations about a certain cloud space

--- a/pkg/devspace/config/generated/config_test.go
+++ b/pkg/devspace/config/generated/config_test.go
@@ -95,9 +95,6 @@ func TestSaveConfig(t *testing.T) {
 		Configs: map[string]*CacheConfig{
 			"SavedActiveConfig": &CacheConfig{},
 		},
-		CloudSpace: &CloudSpaceConfig{
-			Name: "SavedCloudSpaceConfig",
-		},
 	})
 	if err != nil {
 		t.Fatalf("Error saving config: %v", err)
@@ -108,7 +105,6 @@ func TestSaveConfig(t *testing.T) {
 		t.Fatalf("Error loading config: %v", err)
 	}
 	assert.Equal(t, "SavedActiveConfig", returnedConfig.ActiveConfig, "Wrong config saved or returned")
-	assert.Equal(t, "SavedCloudSpaceConfig", returnedConfig.CloudSpace.Name, "Wrong config saved or returned")
 
 	//Now with testDontSaveConfig set true. Loaded config shouldn't change
 	SetTestConfig(&Config{})
@@ -116,9 +112,6 @@ func TestSaveConfig(t *testing.T) {
 		ActiveConfig: "NewActiveConfig",
 		Configs: map[string]*CacheConfig{
 			"NewActiveConfig": &CacheConfig{},
-		},
-		CloudSpace: &CloudSpaceConfig{
-			Name: "NewCloudSpaceConfig",
 		},
 	})
 	if err != nil {
@@ -130,7 +123,6 @@ func TestSaveConfig(t *testing.T) {
 		t.Fatalf("Error loading config: %v", err)
 	}
 	assert.Equal(t, "SavedActiveConfig", returnedConfig.ActiveConfig, "Wrong config saved or returned")
-	assert.Equal(t, "SavedCloudSpaceConfig", returnedConfig.CloudSpace.Name, "Wrong config saved or returned")
 }
 
 func TestGetCaches(t *testing.T) {

--- a/pkg/devspace/configure/deployment.go
+++ b/pkg/devspace/configure/deployment.go
@@ -11,7 +11,6 @@ import (
 	v1 "github.com/devspace-cloud/devspace/pkg/devspace/config/versions/latest"
 	"github.com/devspace-cloud/devspace/pkg/devspace/generator"
 	dockerfileutil "github.com/devspace-cloud/devspace/pkg/util/dockerfile"
-	"github.com/devspace-cloud/devspace/pkg/util/log"
 	"github.com/devspace-cloud/devspace/pkg/util/survey"
 	"github.com/pkg/errors"
 )
@@ -75,20 +74,6 @@ func GetDockerfileComponentDeployment(config *latest.Config, generatedConfig *ge
 		port, err := strconv.Atoi(port)
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "parsing port")
-		}
-
-		if port < 1024 {
-			log.Warn("Your application listens on a system port [0-1024]. Choose a forwarding-port to access your application via localhost.")
-
-			portString := survey.Question(&survey.QuestionOptions{
-				Question:     "Which forwarding port [1024-49151] do you want to use to access your application?",
-				DefaultValue: strconv.Itoa(port + 8000),
-			})
-
-			port, err = strconv.Atoi(portString)
-			if err != nil {
-				return nil, nil, errors.Wrap(err, "parsing port")
-			}
 		}
 
 		retDeploymentConfig.Component.Service = &latest.ServiceConfig{

--- a/pkg/devspace/configure/deployment.go
+++ b/pkg/devspace/configure/deployment.go
@@ -16,7 +16,7 @@ import (
 )
 
 // GetDockerfileComponentDeployment returns a new deployment that deploys an image built from a local dockerfile via a component
-func GetDockerfileComponentDeployment(config *latest.Config, generatedConfig *generated.Config, name, imageName, dockerfile, context, registryURL string) (*latest.ImageConfig, *latest.DeploymentConfig, error) {
+func GetDockerfileComponentDeployment(config *latest.Config, generatedConfig *generated.Config, name, imageName, dockerfile, context string) (*latest.ImageConfig, *latest.DeploymentConfig, error) {
 	var imageConfig *latest.ImageConfig
 	var err error
 	if imageName == "" {
@@ -25,7 +25,7 @@ func GetDockerfileComponentDeployment(config *latest.Config, generatedConfig *ge
 			providerName = &generatedConfig.CloudSpace.ProviderName
 		}
 
-		imageConfig, err = GetImageConfigFromDockerfile(config, dockerfile, context, registryURL, providerName)
+		imageConfig, err = GetImageConfigFromDockerfile(config, dockerfile, context, providerName)
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "get image config")
 		}

--- a/pkg/devspace/configure/deployment.go
+++ b/pkg/devspace/configure/deployment.go
@@ -16,7 +16,7 @@ import (
 )
 
 // GetDockerfileComponentDeployment returns a new deployment that deploys an image built from a local dockerfile via a component
-func GetDockerfileComponentDeployment(config *latest.Config, generatedConfig *generated.Config, name, imageName, dockerfile, context string) (*latest.ImageConfig, *latest.DeploymentConfig, error) {
+func GetDockerfileComponentDeployment(config *latest.Config, generatedConfig *generated.Config, name, imageName, dockerfile, context, registryURL string) (*latest.ImageConfig, *latest.DeploymentConfig, error) {
 	var imageConfig *latest.ImageConfig
 	var err error
 	if imageName == "" {
@@ -25,7 +25,7 @@ func GetDockerfileComponentDeployment(config *latest.Config, generatedConfig *ge
 			providerName = &generatedConfig.CloudSpace.ProviderName
 		}
 
-		imageConfig, err = GetImageConfigFromDockerfile(config, dockerfile, context, providerName)
+		imageConfig, err = GetImageConfigFromDockerfile(config, dockerfile, context, registryURL, providerName)
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "get image config")
 		}

--- a/pkg/devspace/configure/deployment.go
+++ b/pkg/devspace/configure/deployment.go
@@ -16,7 +16,7 @@ import (
 )
 
 // GetDockerfileComponentDeployment returns a new deployment that deploys an image built from a local dockerfile via a component
-func GetDockerfileComponentDeployment(config *latest.Config, generatedConfig *generated.Config, name, imageName, dockerfile, context string) (*latest.ImageConfig, *latest.DeploymentConfig, error) {
+func GetDockerfileComponentDeployment(config *latest.Config, generatedConfig *generated.Config, name, imageName, dockerfile, context string, checkRegistryAuth bool) (*latest.ImageConfig, *latest.DeploymentConfig, error) {
 	var imageConfig *latest.ImageConfig
 	var err error
 	if imageName == "" {
@@ -25,7 +25,7 @@ func GetDockerfileComponentDeployment(config *latest.Config, generatedConfig *ge
 			providerName = &generatedConfig.CloudSpace.ProviderName
 		}
 
-		imageConfig, err = GetImageConfigFromDockerfile(config, dockerfile, context, providerName)
+		imageConfig, err = GetImageConfigFromDockerfile(config, dockerfile, context, providerName, checkRegistryAuth)
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "get image config")
 		}

--- a/pkg/devspace/configure/deployment.go
+++ b/pkg/devspace/configure/deployment.go
@@ -20,12 +20,7 @@ func GetDockerfileComponentDeployment(config *latest.Config, generatedConfig *ge
 	var imageConfig *latest.ImageConfig
 	var err error
 	if imageName == "" {
-		var providerName *string
-		if generatedConfig.CloudSpace != nil {
-			providerName = &generatedConfig.CloudSpace.ProviderName
-		}
-
-		imageConfig, err = GetImageConfigFromDockerfile(config, dockerfile, context, providerName, checkRegistryAuth)
+		imageConfig, err = GetImageConfigFromDockerfile(config, dockerfile, context, checkRegistryAuth)
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "get image config")
 		}

--- a/pkg/devspace/configure/deployment_test.go
+++ b/pkg/devspace/configure/deployment_test.go
@@ -109,7 +109,7 @@ EXPOSE 1012`,
 			survey.SetNextAnswer(answer)
 		}
 
-		imageConfig, deploymentConfig, err := GetDockerfileComponentDeployment(testConfig, generated, testCase.nameParam, testCase.imageName, testCase.dockerfile, testCase.context, "")
+		imageConfig, deploymentConfig, err := GetDockerfileComponentDeployment(testConfig, generated, testCase.nameParam, testCase.imageName, testCase.dockerfile, testCase.context)
 
 		if testCase.expectedErr == "" {
 			assert.NilError(t, err, "Error in testCase %s", testCase.name)

--- a/pkg/devspace/configure/deployment_test.go
+++ b/pkg/devspace/configure/deployment_test.go
@@ -109,7 +109,7 @@ EXPOSE 1012`,
 			survey.SetNextAnswer(answer)
 		}
 
-		imageConfig, deploymentConfig, err := GetDockerfileComponentDeployment(testConfig, generated, testCase.nameParam, testCase.imageName, testCase.dockerfile, testCase.context)
+		imageConfig, deploymentConfig, err := GetDockerfileComponentDeployment(testConfig, generated, testCase.nameParam, testCase.imageName, testCase.dockerfile, testCase.context, "")
 
 		if testCase.expectedErr == "" {
 			assert.NilError(t, err, "Error in testCase %s", testCase.name)
@@ -320,8 +320,8 @@ type removeDeploymentTestCase struct {
 	allFlag             bool
 	existingDeployments []*latest.DeploymentConfig
 
-	expectedErr   string
-	expectedFound bool
+	expectedErr                  string
+	expectedFound                bool
 	expectedRemainingDeployments []string
 }
 
@@ -332,56 +332,56 @@ func TestRemoveDeployment(t *testing.T) {
 			expectedErr: "You have to specify either a deployment name or the --all flag",
 		},
 		removeDeploymentTestCase{
-			name:        "Remove all 2 deployments",
+			name:    "Remove all 2 deployments",
 			allFlag: true,
 			existingDeployments: []*latest.DeploymentConfig{
 				&latest.DeploymentConfig{
-					Name: ptr.String("someDeploy"),
+					Name:      ptr.String("someDeploy"),
 					Component: &latest.ComponentConfig{},
 				},
 				&latest.DeploymentConfig{
-					Name: ptr.String("otherDeploy"),
+					Name:      ptr.String("otherDeploy"),
 					Component: &latest.ComponentConfig{},
 				},
 			},
 			expectedFound: true,
 		},
 		removeDeploymentTestCase{
-			name:        "Remove all 0 deployments",
-			allFlag: true,
+			name:                "Remove all 0 deployments",
+			allFlag:             true,
 			existingDeployments: []*latest.DeploymentConfig{},
-			expectedFound: false,
+			expectedFound:       false,
 		},
 		removeDeploymentTestCase{
-			name:        "Remove 1 of 2 deployments",
+			name:           "Remove 1 of 2 deployments",
 			deploymentName: "someDeploy",
 			existingDeployments: []*latest.DeploymentConfig{
 				&latest.DeploymentConfig{
-					Name: ptr.String("someDeploy"),
+					Name:      ptr.String("someDeploy"),
 					Component: &latest.ComponentConfig{},
 				},
 				&latest.DeploymentConfig{
-					Name: ptr.String("otherDeploy"),
+					Name:      ptr.String("otherDeploy"),
 					Component: &latest.ComponentConfig{},
 				},
 			},
-			expectedFound: true,
+			expectedFound:                true,
 			expectedRemainingDeployments: []string{"otherDeploy"},
 		},
 		removeDeploymentTestCase{
-			name:        "Remove 1 deployment that does not exist",
+			name:           "Remove 1 deployment that does not exist",
 			deploymentName: "notExistent",
 			existingDeployments: []*latest.DeploymentConfig{
 				&latest.DeploymentConfig{
-					Name: ptr.String("someDeploy"),
+					Name:      ptr.String("someDeploy"),
 					Component: &latest.ComponentConfig{},
 				},
 				&latest.DeploymentConfig{
-					Name: ptr.String("otherDeploy"),
+					Name:      ptr.String("otherDeploy"),
 					Component: &latest.ComponentConfig{},
 				},
 			},
-			expectedFound: false,
+			expectedFound:                false,
 			expectedRemainingDeployments: []string{"someDeploy", "otherDeploy"},
 		},
 	}

--- a/pkg/devspace/configure/deployment_test.go
+++ b/pkg/devspace/configure/deployment_test.go
@@ -37,7 +37,7 @@ func TestGetDockerfileComponentDeployment(t *testing.T) {
 	testCases := []GetDockerfileComponentDeploymentTestCase{
 		GetDockerfileComponentDeploymentTestCase{
 			name:          "Empty params, only answers",
-			answers:       []string{"someRegistry.com", "someRegistry.com/user/imagename", "yes", "1234"},
+			answers:       []string{"someRegistry.com", "someRegistry.com/user/imagename", "1234"},
 			expectedImage: "someRegistry.com/user/imagename",
 			expectedPort:  1234,
 		},
@@ -109,7 +109,7 @@ EXPOSE 1012`,
 			survey.SetNextAnswer(answer)
 		}
 
-		imageConfig, deploymentConfig, err := GetDockerfileComponentDeployment(testConfig, generated, testCase.nameParam, testCase.imageName, testCase.dockerfile, testCase.context)
+		imageConfig, deploymentConfig, err := GetDockerfileComponentDeployment(testConfig, generated, testCase.nameParam, testCase.imageName, testCase.dockerfile, testCase.context, false)
 
 		if testCase.expectedErr == "" {
 			assert.NilError(t, err, "Error in testCase %s", testCase.name)
@@ -146,7 +146,7 @@ func TestGetImageComponentDeployment(t *testing.T) {
 	testCases := []getImageComponentDeploymentTestCase{
 		getImageComponentDeploymentTestCase{
 			name:      "valid with port",
-			answers:   []string{"12345", "no"},
+			answers:   []string{"12345"},
 			icdName:   "someDeployment",
 			imageName: "someImage",
 

--- a/pkg/devspace/configure/image.go
+++ b/pkg/devspace/configure/image.go
@@ -27,42 +27,38 @@ const dockerHubHostname = "hub.docker.com"
 
 // GetImageConfigFromImageName returns an image config based on the image
 func GetImageConfigFromImageName(imageName, dockerfile, context string) *latest.ImageConfig {
-	if dockerfile != "" {
-		// Figure out tag
-		imageTag := ""
-		splittedImage := strings.Split(imageName, ":")
-		imageName = splittedImage[0]
-		if len(splittedImage) > 1 {
-			imageTag = splittedImage[1]
-		} else if dockerfile == "" {
-			imageTag = "latest"
-		}
-
-		retImageConfig := &latest.ImageConfig{
-			Image:            &imageName,
-			CreatePullSecret: ptr.Bool(true),
-		}
-
-		if imageTag != "" {
-			retImageConfig.Tag = &imageTag
-		}
-		if dockerfile == "" {
-			retImageConfig.Build = &latest.BuildConfig{
-				Disabled: ptr.Bool(true),
-			}
-		} else {
-			if dockerfile != helper.DefaultDockerfilePath {
-				retImageConfig.Dockerfile = &dockerfile
-			}
-			if context != "" && context != helper.DefaultContextPath {
-				retImageConfig.Context = &context
-			}
-		}
-
-		return retImageConfig
+	// Figure out tag
+	imageTag := ""
+	splittedImage := strings.Split(imageName, ":")
+	imageName = splittedImage[0]
+	if len(splittedImage) > 1 {
+		imageTag = splittedImage[1]
+	} else if dockerfile == "" {
+		imageTag = "latest"
 	}
 
-	return nil
+	retImageConfig := &latest.ImageConfig{
+		Image:            &imageName,
+		CreatePullSecret: ptr.Bool(true),
+	}
+
+	if imageTag != "" {
+		retImageConfig.Tag = &imageTag
+	}
+	if dockerfile == "" {
+		retImageConfig.Build = &latest.BuildConfig{
+			Disabled: ptr.Bool(true),
+		}
+	} else {
+		if dockerfile != helper.DefaultDockerfilePath {
+			retImageConfig.Dockerfile = &dockerfile
+		}
+		if context != "" && context != helper.DefaultContextPath {
+			retImageConfig.Context = &context
+		}
+	}
+
+	return retImageConfig
 }
 
 // GetImageConfigFromDockerfile gets the image config based on the configured cloud provider or asks the user where to push to

--- a/pkg/devspace/configure/image_test.go
+++ b/pkg/devspace/configure/image_test.go
@@ -129,7 +129,7 @@ func TestGetImageConfigFromDockerfile(t *testing.T) {
 		}
 		fsutil.WriteToFile([]byte(testCase.providersYaml), filepath.Join(dir, "providers.yaml"))
 
-		imageConfig, err := GetImageConfigFromDockerfile(testConfig, testCase.dockerfile, testCase.context, testCase.cloudProvider)
+		imageConfig, err := GetImageConfigFromDockerfile(testConfig, testCase.dockerfile, testCase.context, "", testCase.cloudProvider)
 
 		if testCase.expectedErr == "" {
 			assert.NilError(t, err, "Error in testCase %s", testCase.name)

--- a/pkg/devspace/configure/image_test.go
+++ b/pkg/devspace/configure/image_test.go
@@ -129,7 +129,7 @@ func TestGetImageConfigFromDockerfile(t *testing.T) {
 		}
 		fsutil.WriteToFile([]byte(testCase.providersYaml), filepath.Join(dir, "providers.yaml"))
 
-		imageConfig, err := GetImageConfigFromDockerfile(testConfig, testCase.dockerfile, testCase.context, "", testCase.cloudProvider)
+		imageConfig, err := GetImageConfigFromDockerfile(testConfig, testCase.dockerfile, testCase.context, testCase.cloudProvider)
 
 		if testCase.expectedErr == "" {
 			assert.NilError(t, err, "Error in testCase %s", testCase.name)

--- a/pkg/devspace/configure/image_test.go
+++ b/pkg/devspace/configure/image_test.go
@@ -129,7 +129,7 @@ func TestGetImageConfigFromDockerfile(t *testing.T) {
 		}
 		fsutil.WriteToFile([]byte(testCase.providersYaml), filepath.Join(dir, "providers.yaml"))
 
-		imageConfig, err := GetImageConfigFromDockerfile(testConfig, testCase.dockerfile, testCase.context, testCase.cloudProvider)
+		imageConfig, err := GetImageConfigFromDockerfile(testConfig, testCase.dockerfile, testCase.context, testCase.cloudProvider, false)
 
 		if testCase.expectedErr == "" {
 			assert.NilError(t, err, "Error in testCase %s", testCase.name)

--- a/pkg/devspace/configure/image_test.go
+++ b/pkg/devspace/configure/image_test.go
@@ -129,7 +129,7 @@ func TestGetImageConfigFromDockerfile(t *testing.T) {
 		}
 		fsutil.WriteToFile([]byte(testCase.providersYaml), filepath.Join(dir, "providers.yaml"))
 
-		imageConfig, err := GetImageConfigFromDockerfile(testConfig, testCase.dockerfile, testCase.context, testCase.cloudProvider, false)
+		imageConfig, err := GetImageConfigFromDockerfile(testConfig, testCase.dockerfile, testCase.context, false)
 
 		if testCase.expectedErr == "" {
 			assert.NilError(t, err, "Error in testCase %s", testCase.name)

--- a/pkg/devspace/generator/language.go
+++ b/pkg/devspace/generator/language.go
@@ -75,10 +75,11 @@ func ContainerizeApplication(dockerfilePath, localPath string, templateRepoURL s
 
 	// Let the user select the language
 	selectedLanguage := survey.Question(&survey.QuestionOptions{
-		Question:     "Select programming language of project",
+		Question:     "Select the programming language of this project",
 		DefaultValue: detectedLang,
 		Options:      supportedLanguages,
 	})
+	log.WriteString("\n")
 
 	return dockerfileGenerator.CreateDockerfile(selectedLanguage)
 }

--- a/pkg/devspace/kubectl/util.go
+++ b/pkg/devspace/kubectl/util.go
@@ -14,6 +14,7 @@ import (
 	"github.com/devspace-cloud/devspace/pkg/devspace/kubectl/minikube"
 	"github.com/devspace-cloud/devspace/pkg/util/log"
 	"github.com/devspace-cloud/devspace/pkg/util/ptr"
+	"github.com/mgutz/ansi"
 	k8sv1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/rbac/v1beta1"
@@ -65,15 +66,22 @@ func EnsureDefaultNamespace(config *latest.Config, client kubernetes.Interface, 
 	if defaultNamespace != "default" {
 		_, err = client.CoreV1().Namespaces().Get(defaultNamespace, metav1.GetOptions{})
 		if err != nil {
-			log.Donef("Create namespace %s", defaultNamespace)
-
 			// Create release namespace
 			_, err = client.CoreV1().Namespaces().Create(&v1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: defaultNamespace,
 				},
 			})
+
+			log.Donef("Created namespace %s", defaultNamespace)
 		}
+	} else {
+		log.Warn("You are deploying to the 'default' namespace of your cluster. This is highly discouraged as this namespace cannot be deleted.")
+		log.Infof("\r          \nPlease run: \n- `%s` to tell DevSpace to deploy to this namespace \n- `%s` to create a new space in DevSpace Cloud\n- `%s` to use an existing space\n", ansi.Color("devspace use namespace [NAME]", "white+b"), ansi.Color("devspace create space [NAME]", "white+b"), ansi.Color("devspace use space [NAME]", "white+b"))
+
+		log.StartWait("Will continue to deploy in 5 seconds")
+		time.Sleep(5 * time.Second)
+		log.StopWait()
 	}
 
 	return err

--- a/pkg/devspace/kubectl/util.go
+++ b/pkg/devspace/kubectl/util.go
@@ -14,7 +14,6 @@ import (
 	"github.com/devspace-cloud/devspace/pkg/devspace/kubectl/minikube"
 	"github.com/devspace-cloud/devspace/pkg/util/log"
 	"github.com/devspace-cloud/devspace/pkg/util/ptr"
-	"github.com/mgutz/ansi"
 	k8sv1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/rbac/v1beta1"
@@ -63,25 +62,16 @@ func EnsureDefaultNamespace(config *latest.Config, client kubernetes.Interface, 
 		return fmt.Errorf("Error getting default namespace: %v", err)
 	}
 
-	if defaultNamespace != "default" {
-		_, err = client.CoreV1().Namespaces().Get(defaultNamespace, metav1.GetOptions{})
-		if err != nil {
-			// Create release namespace
-			_, err = client.CoreV1().Namespaces().Create(&v1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: defaultNamespace,
-				},
-			})
+	_, err = client.CoreV1().Namespaces().Get(defaultNamespace, metav1.GetOptions{})
+	if err != nil {
+		// Create release namespace
+		_, err = client.CoreV1().Namespaces().Create(&v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: defaultNamespace,
+			},
+		})
 
-			log.Donef("Created namespace %s", defaultNamespace)
-		}
-	} else {
-		log.Warn("You are deploying to the 'default' namespace of your cluster. This is highly discouraged as this namespace cannot be deleted.")
-		log.Infof("\r          \nPlease run: \n- `%s` to tell DevSpace to deploy to this namespace \n- `%s` to create a new space in DevSpace Cloud\n- `%s` to use an existing space\n", ansi.Color("devspace use namespace [NAME]", "white+b"), ansi.Color("devspace create space [NAME]", "white+b"), ansi.Color("devspace use space [NAME]", "white+b"))
-
-		log.StartWait("Will continue to deploy in 5 seconds")
-		time.Sleep(5 * time.Second)
-		log.StopWait()
+		log.Donef("Created namespace %s", defaultNamespace)
 	}
 
 	return err

--- a/pkg/devspace/registry/init.go
+++ b/pkg/devspace/registry/init.go
@@ -26,8 +26,12 @@ func CreatePullSecrets(config *latest.Config, dockerClient client.CommonAPIClien
 				if err != nil {
 					return err
 				}
+				displayRegistryURL := registryURL
 
-				log.StartWait("Creating image pull secret for registry: " + registryURL)
+				if displayRegistryURL == "" {
+					displayRegistryURL = "hub.docker.com"
+				}
+				log.StartWait("Creating image pull secret for registry: " + displayRegistryURL)
 				err = createPullSecretForRegistry(config, dockerClient, client, registryURL, log)
 				log.StopWait()
 				if err != nil {

--- a/pkg/devspace/registry/init_test.go
+++ b/pkg/devspace/registry/init_test.go
@@ -71,7 +71,7 @@ func TestCreatePullSecrets(t *testing.T) {
 				},
 			},
 			expectedLog: `
-StartWait Creating image pull secret for registry: 
+StartWait Creating image pull secret for registry: hub.docker.com
 StopWait
 Error Couldn't find service account 'default' in namespace 'testNS': serviceaccounts "default" not found`,
 		},
@@ -86,7 +86,7 @@ Error Couldn't find service account 'default' in namespace 'testNS': serviceacco
 				},
 			},
 			expectedLog: `
-StartWait Creating image pull secret for registry: 
+StartWait Creating image pull secret for registry: hub.docker.com
 StopWait`,
 		},
 	}

--- a/pkg/util/kubeconfig/kubeconfig.go
+++ b/pkg/util/kubeconfig/kubeconfig.go
@@ -80,8 +80,8 @@ func LoadNewConfig(contextName, server, caCert, token, namespace string) (client
 	return clientcmd.NewNonInteractiveClientConfig(*config, contextName, &clientcmd.ConfigOverrides{}, clientcmd.NewDefaultClientConfigLoadingRules()), nil
 }
 
-// ContextIsCloudSpace returns true of this context belongs to a Space created by DevSpace Cloud
-func ContextIsCloudSpace(context *api.Context) (bool, error) {
+// IsCloudSpace returns true of this context belongs to a Space created by DevSpace Cloud
+func IsCloudSpace(context *api.Context) (bool, error) {
 	// Get AuthInfo for context
 	authInfo, err := GetAuthInfo(context)
 	if err != nil {
@@ -112,6 +112,16 @@ func GetSpaceID(context *api.Context) (int, string, error) {
 	spaceID, err := strconv.Atoi(authInfo.Exec.Args[5])
 
 	return spaceID, authInfo.Exec.Args[3], err
+}
+
+// GetCurrentContextSpaceID returns the id and the provider of the Space that belongs to the current context
+func GetCurrentContextSpaceID() (int, string, error) {
+	currentContext, _, err := GetCurrentContext()
+	if err != nil {
+		return 0, "", fmt.Errorf("Unable to get current kube-context: %v", err)
+	}
+
+	return GetSpaceID(currentContext)
 }
 
 // GetAuthInfo returns the AuthInfo of the context with this name

--- a/pkg/util/log/loading_text.go
+++ b/pkg/util/log/loading_text.go
@@ -108,7 +108,7 @@ func (l *loadingText) render() {
 	}
 	messagePrefix := []byte("[wait] ")
 
-	l.Stream.Write([]byte(ansi.Color(string(messagePrefix), "red+b")))
+	l.Stream.Write([]byte(ansi.Color(string(messagePrefix), "cyan+b")))
 
 	timeElapsed := fmt.Sprintf("%d", (time.Now().UnixNano()-l.StartTimestamp)/int64(time.Second))
 	message := []byte(l.getLoadingChar() + " " + l.Message)

--- a/pkg/util/log/stdout_logger.go
+++ b/pkg/util/log/stdout_logger.go
@@ -47,7 +47,7 @@ var fnTypeInformationMap = map[logFunctionType]*fnTypeInformation{
 	},
 	warnFn: {
 		tag:      "[warn]   ",
-		color:    "166+b",
+		color:    "red+b",
 		logLevel: logrus.WarnLevel,
 		stream:   stdout,
 	},


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others)  
/kind enhancement


**What is this pull request for? Which issues does it resolve?** (use `resolves #<issue_number>` if possible)  
This PR changes the behavior of init (see below) and adds a the `--interactive / -i` flag to `devspace dev`.

Also resolves #655 


**Does this pull request has user-facing changes?** (e.g. config changes, new/modified commands, new/modified flags)  
Yes:
- `init` warns when application listens on a system port and asks for forwarding port
- `init` now writes a different config which by default disables the terminal and does not override the entrypoint anymore

**Does this pull request add new dependencies?**  
No

**What else do we need to know?**  
Due to a cobra issue (https://github.com/spf13/cobra/issues/866), the --interactive flag must be used as `-i/--interactive=value` instead of `-i/--interactive value` (or alternatively without value at all).
