### PR TITLE
Refactor config loading

### DIFF
--- a/cmd/add/deployment.go
+++ b/cmd/add/deployment.go
@@ -114,7 +114,7 @@ func (cmd *deploymentCmd) RunAddDeployment(cobraCmd *cobra.Command, args []strin
 	} else if cmd.Chart != "" {
 		newDeployment, err = configure.GetHelmDeployment(deploymentName, cmd.Chart, cmd.ChartRepo, cmd.ChartVersion)
 	} else if cmd.Dockerfile != "" {
-		generatedConfig, err := generated.LoadConfig(context.Background())
+		generatedConfig, err := generated.LoadConfig("")
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -1,11 +1,10 @@
 package cmd
 
 import (
-	"context"
-
 	"github.com/devspace-cloud/devspace/pkg/devspace/analyze"
 	"github.com/devspace-cloud/devspace/pkg/devspace/cloud"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/configutil"
+	"github.com/devspace-cloud/devspace/pkg/devspace/config/generated"
 	"github.com/devspace-cloud/devspace/pkg/devspace/kubectl"
 	"github.com/devspace-cloud/devspace/pkg/util/log"
 	"github.com/spf13/cobra"
@@ -53,9 +52,18 @@ devspace analyze --namespace=mynamespace
 // RunAnalyze executes the functionality "devspace analyze"
 func (cmd *AnalyzeCmd) RunAnalyze(cobraCmd *cobra.Command, args []string) {
 	// Set config root
-	_, err := configutil.SetDevSpaceRoot()
+	configExists, err := configutil.SetDevSpaceRoot()
 	if err != nil {
 		log.Fatal(err)
+	}
+
+	// Load generated config if possible
+	var generatedConfig *generated.Config
+	if configExists {
+		generatedConfig, err = generated.LoadConfig("")
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 
 	// Create kubectl client
@@ -65,7 +73,7 @@ func (cmd *AnalyzeCmd) RunAnalyze(cobraCmd *cobra.Command, args []string) {
 	}
 
 	// Print warning
-	err = client.PrintWarning(context.Background(), false, log.GetInstance())
+	err = client.PrintWarning(generatedConfig, false, log.GetInstance())
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -9,7 +9,6 @@ import (
 	"github.com/mgutz/ansi"
 
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/configutil"
-	"github.com/devspace-cloud/devspace/pkg/devspace/config/constants"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/generated"
 	"github.com/devspace-cloud/devspace/pkg/util/log"
 	"github.com/spf13/cobra"
@@ -69,20 +68,14 @@ func (cmd *BuildCmd) Run(cobraCmd *cobra.Command, args []string) {
 	// Start file logging
 	log.StartFileLogging()
 
-	// Get config with adjusted cluster config
-	ctx := context.Background()
-	if cmd.Profile != "" {
-		ctx = context.WithValue(ctx, constants.ProfileContextKey, cmd.Profile)
-	}
-
 	// Load config
-	generatedConfig, err := generated.LoadConfig(ctx)
+	generatedConfig, err := generated.LoadConfig(cmd.Profile)
 	if err != nil {
 		log.Fatalf("Error loading generated.yaml: %v", err)
 	}
 
 	// Get the config
-	config := configutil.GetConfig(ctx)
+	config := configutil.GetConfig(context.Background(), cmd.Profile)
 
 	// Dependencies
 	err = dependency.BuildAll(config, generatedConfig, cmd.AllowCyclicDependencies, false, cmd.SkipPush, cmd.ForceDependencies, cmd.ForceBuild, log.GetInstance())

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -18,6 +18,7 @@ import (
 type BuildCmd struct {
 	SkipPush                bool
 	AllowCyclicDependencies bool
+	VerboseDependencies     bool
 
 	ForceBuild        bool
 	BuildSequential   bool
@@ -48,6 +49,7 @@ Builds all defined images and pushes them
 	buildCmd.Flags().BoolVarP(&cmd.ForceBuild, "force-build", "b", false, "Forces to build every image")
 	buildCmd.Flags().BoolVar(&cmd.BuildSequential, "build-sequential", false, "Builds the images one after another instead of in parallel")
 	buildCmd.Flags().BoolVar(&cmd.ForceDependencies, "force-dependencies", false, "Forces to re-evaluate dependencies (use with --force-build --force-deploy to actually force building & deployment of dependencies)")
+	buildCmd.Flags().BoolVar(&cmd.VerboseDependencies, "verbose-dependencies", false, "Builds the dependencies verbosely")
 
 	buildCmd.Flags().BoolVar(&cmd.SkipPush, "skip-push", false, "Skips image pushing, useful for minikube deployment")
 
@@ -78,7 +80,7 @@ func (cmd *BuildCmd) Run(cobraCmd *cobra.Command, args []string) {
 	config := configutil.GetConfig(context.Background(), cmd.Profile)
 
 	// Dependencies
-	err = dependency.BuildAll(config, generatedConfig, cmd.AllowCyclicDependencies, false, cmd.SkipPush, cmd.ForceDependencies, cmd.ForceBuild, log.GetInstance())
+	err = dependency.BuildAll(config, generatedConfig, cmd.AllowCyclicDependencies, false, cmd.SkipPush, cmd.ForceDependencies, cmd.ForceBuild, cmd.VerboseDependencies, log.GetInstance())
 	if err != nil {
 		log.Fatalf("Error deploying dependencies: %v", err)
 	}

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -86,7 +86,7 @@ func (cmd *BuildCmd) Run(cobraCmd *cobra.Command, args []string) {
 	}
 
 	// Build images if necessary
-	builtImages, err := build.All(config, generatedConfig.GetActive(), nil, cmd.SkipPush, true, cmd.ForceBuild, cmd.BuildSequential, log.GetInstance())
+	builtImages, err := build.All(config, generatedConfig.GetActive(), nil, cmd.SkipPush, true, cmd.ForceBuild, cmd.BuildSequential, false, log.GetInstance())
 	if err != nil {
 		if strings.Index(err.Error(), "no space left on device") != -1 {
 			log.Fatalf("Error building image: %v\n\n Try running `%s` to free docker daemon space and retry", err, ansi.Color("devspace cleanup images", "white+b"))

--- a/cmd/cleanup/images.go
+++ b/cmd/cleanup/images.go
@@ -47,7 +47,7 @@ func (cmd *imagesCmd) RunCleanupImages(cobraCmd *cobra.Command, args []string) {
 	}
 
 	// Load config
-	config := configutil.GetConfig(context.Background())
+	config := configutil.GetConfig(context.Background(), "")
 	if config.Images == nil || len(config.Images) == 0 {
 		log.Done("No images found in config to delete")
 		return

--- a/cmd/create/space.go
+++ b/cmd/create/space.go
@@ -1,8 +1,6 @@
 package create
 
 import (
-	"context"
-
 	"github.com/devspace-cloud/devspace/pkg/devspace/cloud"
 	"github.com/devspace-cloud/devspace/pkg/devspace/cloud/config/versions/latest"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/configutil"
@@ -140,7 +138,7 @@ func (cmd *spaceCmd) RunCreateSpace(cobraCmd *cobra.Command, args []string) {
 
 	if configExists {
 		// Get generated config
-		generatedConfig, err := generated.LoadConfig(context.Background())
+		generatedConfig, err := generated.LoadConfig("")
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -99,14 +99,8 @@ func (cmd *DeployCmd) Run(cobraCmd *cobra.Command, args []string) {
 	// Validate flags
 	cmd.validateFlags()
 
-	// Get config with adjusted cluster config
-	ctx := context.Background()
-	if cmd.Profile != "" {
-		ctx = context.WithValue(ctx, constants.ProfileContextKey, cmd.Profile)
-	}
-
 	// Load generated config
-	generatedConfig, err := generated.LoadConfig(ctx)
+	generatedConfig, err := generated.LoadConfig(cmd.Profile)
 	if err != nil {
 		log.Fatalf("Error loading generated.yaml: %v", err)
 	}
@@ -118,15 +112,15 @@ func (cmd *DeployCmd) Run(cobraCmd *cobra.Command, args []string) {
 	}
 
 	// Warn the user if we deployed into a different context before
-	err = client.PrintWarning(ctx, true, log.GetInstance())
+	err = client.PrintWarning(generatedConfig, true, log.GetInstance())
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	// Add current kube context to context
-	ctx = context.WithValue(ctx, constants.KubeContextKey, client.CurrentContext)
+	ctx := context.WithValue(context.Background(), constants.KubeContextKey, client.CurrentContext)
 
-	config := configutil.GetConfig(ctx)
+	config := configutil.GetConfig(ctx, cmd.Profile)
 
 	// Signal that we are working on the space if there is any
 	err = cloud.ResumeSpace(client, true, log.GetInstance())

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -28,12 +28,13 @@ type DeployCmd struct {
 
 	DockerTarget string
 
-	ForceBuild        bool
-	SkipBuild         bool
-	BuildSequential   bool
-	ForceDeploy       bool
-	Deployments       string
-	ForceDependencies bool
+	ForceBuild          bool
+	SkipBuild           bool
+	BuildSequential     bool
+	ForceDeploy         bool
+	Deployments         string
+	ForceDependencies   bool
+	VerboseDependencies bool
 
 	SwitchContext bool
 	SkipPush      bool
@@ -64,6 +65,7 @@ devspace deploy --kube-context=deploy-context
 	}
 
 	deployCmd.Flags().BoolVar(&cmd.AllowCyclicDependencies, "allow-cyclic", false, "When enabled allows cyclic dependencies")
+	deployCmd.Flags().BoolVar(&cmd.VerboseDependencies, "verbose-dependencies", false, "Deploys the dependencies verbosely")
 
 	deployCmd.Flags().StringVarP(&cmd.Namespace, "namespace", "n", "", "The namespace to deploy to")
 	deployCmd.Flags().StringVar(&cmd.KubeContext, "kube-context", "", "The kubernetes context to use for deployment")
@@ -153,7 +155,7 @@ func (cmd *DeployCmd) Run(cobraCmd *cobra.Command, args []string) {
 	}
 
 	// Dependencies
-	err = dependency.DeployAll(config, generatedConfig, client, cmd.AllowCyclicDependencies, false, cmd.SkipPush, cmd.ForceDependencies, cmd.SkipBuild, cmd.ForceBuild, cmd.ForceDeploy, log.GetInstance())
+	err = dependency.DeployAll(config, generatedConfig, client, cmd.AllowCyclicDependencies, false, cmd.SkipPush, cmd.ForceDependencies, cmd.SkipBuild, cmd.ForceBuild, cmd.ForceDeploy, cmd.VerboseDependencies, log.GetInstance())
 	if err != nil {
 		log.Fatalf("Error deploying dependencies: %v", err)
 	}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -163,7 +163,7 @@ func (cmd *DeployCmd) Run(cobraCmd *cobra.Command, args []string) {
 	// Build images
 	builtImages := make(map[string]string)
 	if cmd.SkipBuild == false {
-		builtImages, err = build.All(config, generatedConfig.GetActive(), client, cmd.SkipPush, false, cmd.ForceBuild, cmd.BuildSequential, log.GetInstance())
+		builtImages, err = build.All(config, generatedConfig.GetActive(), client, cmd.SkipPush, false, cmd.ForceBuild, cmd.BuildSequential, false, log.GetInstance())
 		if err != nil {
 			if strings.Index(err.Error(), "no space left on device") != -1 {
 				err = fmt.Errorf("%v\n\n Try running `%s` to free docker daemon space and retry", err, ansi.Color("devspace cleanup images", "white+b"))

--- a/cmd/dev.go
+++ b/cmd/dev.go
@@ -36,6 +36,7 @@ import (
 type DevCmd struct {
 	SkipPush                bool
 	AllowCyclicDependencies bool
+	VerboseDependencies     bool
 
 	ForceBuild        bool
 	SkipBuild         bool
@@ -90,6 +91,7 @@ Use Interactive Mode:
 	}
 
 	devCmd.Flags().BoolVar(&cmd.AllowCyclicDependencies, "allow-cyclic", false, "When enabled allows cyclic dependencies")
+	devCmd.Flags().BoolVar(&cmd.VerboseDependencies, "verbose-dependencies", false, "Deploys the dependencies verbosely")
 
 	devCmd.Flags().BoolVarP(&cmd.ForceBuild, "force-build", "b", false, "Forces to build every image")
 	devCmd.Flags().BoolVar(&cmd.SkipBuild, "skip-build", false, "Skips building of images")
@@ -207,7 +209,7 @@ func (cmd *DevCmd) Run(cobraCmd *cobra.Command, args []string) {
 func (cmd *DevCmd) buildAndDeploy(ctx context.Context, config *latest.Config, generatedConfig *generated.Config, client *kubectl.Client, args []string) (int, error) {
 	if cmd.SkipPipeline == false {
 		// Dependencies
-		err := dependency.DeployAll(config, generatedConfig, client, cmd.AllowCyclicDependencies, false, cmd.SkipPush, cmd.ForceDependencies, cmd.SkipBuild, cmd.ForceBuild, cmd.ForceDeploy, log.GetInstance())
+		err := dependency.DeployAll(config, generatedConfig, client, cmd.AllowCyclicDependencies, false, cmd.SkipPush, cmd.ForceDependencies, cmd.SkipBuild, cmd.ForceBuild, cmd.ForceDeploy, cmd.VerboseDependencies, log.GetInstance())
 		if err != nil {
 			return 0, fmt.Errorf("Error deploying dependencies: %v", err)
 		}

--- a/cmd/dev.go
+++ b/cmd/dev.go
@@ -197,7 +197,7 @@ func (cmd *DevCmd) Run(cobraCmd *cobra.Command, args []string) {
 	}
 
 	// Build and deploy images
-	exitCode, err := cmd.buildAndDeploy(ctx, config, generatedConfig, client, args)
+	exitCode, err := cmd.buildAndDeploy(ctx, config, generatedConfig, client, args, true)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -206,7 +206,7 @@ func (cmd *DevCmd) Run(cobraCmd *cobra.Command, args []string) {
 	os.Exit(exitCode)
 }
 
-func (cmd *DevCmd) buildAndDeploy(ctx context.Context, config *latest.Config, generatedConfig *generated.Config, client *kubectl.Client, args []string) (int, error) {
+func (cmd *DevCmd) buildAndDeploy(ctx context.Context, config *latest.Config, generatedConfig *generated.Config, client *kubectl.Client, args []string, skipBuildIfAlreadyBuilt bool) (int, error) {
 	if cmd.SkipPipeline == false {
 		// Dependencies
 		err := dependency.DeployAll(config, generatedConfig, client, cmd.AllowCyclicDependencies, false, cmd.SkipPush, cmd.ForceDependencies, cmd.SkipBuild, cmd.ForceBuild, cmd.ForceDeploy, cmd.VerboseDependencies, log.GetInstance())
@@ -217,7 +217,7 @@ func (cmd *DevCmd) buildAndDeploy(ctx context.Context, config *latest.Config, ge
 		// Build image if necessary
 		builtImages := make(map[string]string)
 		if cmd.SkipBuild == false {
-			builtImages, err = build.All(config, generatedConfig.GetActive(), client, cmd.SkipPush, true, cmd.ForceBuild, cmd.BuildSequential, log.GetInstance())
+			builtImages, err = build.All(config, generatedConfig.GetActive(), client, cmd.SkipPush, true, cmd.ForceBuild, cmd.BuildSequential, skipBuildIfAlreadyBuilt, log.GetInstance())
 			if err != nil {
 				if strings.Index(err.Error(), "no space left on device") != -1 {
 					return 0, fmt.Errorf("Error building image: %v\n\n Try running `%s` to free docker daemon space and retry", err, ansi.Color("devspace cleanup images", "white+b"))
@@ -274,7 +274,7 @@ func (cmd *DevCmd) buildAndDeploy(ctx context.Context, config *latest.Config, ge
 				config := cmd.loadConfig(ctx)
 
 				// Trigger rebuild & redeploy
-				return cmd.buildAndDeploy(ctx, config, generatedConfig, client, args)
+				return cmd.buildAndDeploy(ctx, config, generatedConfig, client, args, false)
 			}
 
 			return 0, err
@@ -320,7 +320,7 @@ func (cmd *DevCmd) startServices(ctx context.Context, config *latest.Config, gen
 	// Start watcher if we have at least one auto reload path and if we should not skip the pipeline
 	if cmd.SkipPipeline == false && len(autoReloadPaths) > 0 {
 		var once sync.Once
-		watcher, err := watch.New(autoReloadPaths, func(changed []string, deleted []string) error {
+		watcher, err := watch.New(autoReloadPaths, []string{".devspace/"}, func(changed []string, deleted []string) error {
 			once.Do(func() {
 				if interactiveMode {
 					log.Info("Change detected, will reload in 2 seconds")

--- a/cmd/enter.go
+++ b/cmd/enter.go
@@ -7,6 +7,7 @@ import (
 	"github.com/devspace-cloud/devspace/pkg/devspace/cloud"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/configutil"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/constants"
+	"github.com/devspace-cloud/devspace/pkg/devspace/config/generated"
 	latest "github.com/devspace-cloud/devspace/pkg/devspace/config/versions/latest"
 	"github.com/devspace-cloud/devspace/pkg/devspace/kubectl"
 	"github.com/devspace-cloud/devspace/pkg/devspace/services"
@@ -72,9 +73,18 @@ devspace enter bash -l release=test
 // Run executes the command logic
 func (cmd *EnterCmd) Run(cobraCmd *cobra.Command, args []string) {
 	// Set config root
-	_, err := configutil.SetDevSpaceRoot()
+	configExists, err := configutil.SetDevSpaceRoot()
 	if err != nil {
 		log.Fatal(err)
+	}
+
+	// Load generated config if possible
+	var generatedConfig *generated.Config
+	if configExists {
+		generatedConfig, err = generated.LoadConfig("")
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 
 	// Get kubectl client
@@ -83,7 +93,7 @@ func (cmd *EnterCmd) Run(cobraCmd *cobra.Command, args []string) {
 		log.Fatalf("Unable to create new kubectl client: %v", err)
 	}
 
-	err = client.PrintWarning(context.Background(), false, log.GetInstance())
+	err = client.PrintWarning(generatedConfig, false, log.GetInstance())
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -97,7 +107,7 @@ func (cmd *EnterCmd) Run(cobraCmd *cobra.Command, args []string) {
 	// Get config
 	var config *latest.Config
 	if configutil.ConfigExists() {
-		config = configutil.GetConfig(context.WithValue(context.Background(), constants.KubeContextKey, client.CurrentContext))
+		config = configutil.GetConfig(context.WithValue(context.Background(), constants.KubeContextKey, client.CurrentContext), "")
 	}
 
 	// Build params

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -196,7 +196,7 @@ func (cmd *InitCmd) Run(cobraCmd *cobra.Command, args []string) {
 			log.Fatalf("Couldn't find dockerfile at '%s'. Please make sure you have a Dockerfile at the specified location", cmd.Dockerfile)
 		}
 
-		generatedConfig, err := generated.LoadConfig(context.Background())
+		generatedConfig, err := generated.LoadConfig("")
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -287,7 +287,7 @@ func getDeploymentName() (string, error) {
 }
 
 func (cmd *InitCmd) addDevConfig() {
-	config := configutil.GetConfig(context.Background())
+	config := configutil.GetConfig(context.Background(), "")
 
 	// Forward ports
 	if len(config.Deployments) > 0 && config.Deployments[0].Component != nil && config.Deployments[0].Component.Service != nil && config.Deployments[0].Component.Service.Ports != nil && len(config.Deployments[0].Component.Service.Ports) > 0 {

--- a/cmd/list/deployments.go
+++ b/cmd/list/deployments.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/devspace-cloud/devspace/pkg/devspace/cloud"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/configutil"
+	"github.com/devspace-cloud/devspace/pkg/devspace/config/generated"
 	"github.com/devspace-cloud/devspace/pkg/devspace/deploy"
 	deployComponent "github.com/devspace-cloud/devspace/pkg/devspace/deploy/component"
 	deployHelm "github.com/devspace-cloud/devspace/pkg/devspace/deploy/helm"
@@ -53,6 +54,12 @@ func (cmd *deploymentsCmd) RunDeploymentsStatus(cobraCmd *cobra.Command, args []
 		"STATUS",
 	}
 
+	// Load generated
+	generatedConfig, err := generated.LoadConfig("")
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	// Create new kube client
 	client, err := kubectl.NewDefaultClient()
 	if err != nil {
@@ -60,13 +67,13 @@ func (cmd *deploymentsCmd) RunDeploymentsStatus(cobraCmd *cobra.Command, args []
 	}
 
 	// Show warning if the old kube context was different
-	err = client.PrintWarning(context.Background(), false, log.GetInstance())
+	err = client.PrintWarning(generatedConfig, false, log.GetInstance())
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	// Get config with adjusted cluster config
-	config := configutil.GetConfig(context.Background())
+	config := configutil.GetConfig(context.Background(), "")
 
 	// Signal that we are working on the space if there is any
 	err = cloud.ResumeSpace(client, true, log.GetInstance())

--- a/cmd/list/ports.go
+++ b/cmd/list/ports.go
@@ -42,7 +42,7 @@ func (cmd *portsCmd) RunListPort(cobraCmd *cobra.Command, args []string) {
 		log.Fatal("Couldn't find a DevSpace configuration. Please run `devspace init`")
 	}
 
-	config := configutil.GetConfig(context.Background())
+	config := configutil.GetConfig(context.Background(), "")
 
 	if config.Dev.Ports == nil || len(config.Dev.Ports) == 0 {
 		log.Info("No ports are forwarded. Run `devspace add port` to add a port that should be forwarded\n")

--- a/cmd/list/profiles.go
+++ b/cmd/list/profiles.go
@@ -1,7 +1,6 @@
 package list
 
 import (
-	"context"
 	"strconv"
 
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/configutil"
@@ -50,7 +49,7 @@ func (cmd *profilesCmd) RunListProfiles(cobraCmd *cobra.Command, args []string) 
 	}
 
 	// Load generated config
-	generatedConfig, err := generated.LoadConfig(context.Background())
+	generatedConfig, err := generated.LoadConfig("")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/list/selectors.go
+++ b/cmd/list/selectors.go
@@ -42,7 +42,7 @@ func (cmd *selectorsCmd) RunListSelectors(cobraCmd *cobra.Command, args []string
 		log.Fatal("Couldn't find a DevSpace configuration. Please run `devspace init`")
 	}
 
-	config := configutil.GetConfig(context.Background())
+	config := configutil.GetConfig(context.Background(), "")
 
 	if config.Dev.Selectors == nil || len(config.Dev.Selectors) == 0 {
 		log.Info("No selectors are configured. Run `devspace add selector` to add new selector\n")

--- a/cmd/list/sync.go
+++ b/cmd/list/sync.go
@@ -41,7 +41,7 @@ func (cmd *syncCmd) RunListSync(cobraCmd *cobra.Command, args []string) {
 		log.Fatal("Couldn't find any devspace configuration. Please run `devspace init`")
 	}
 
-	config := configutil.GetConfig(context.Background())
+	config := configutil.GetConfig(context.Background(), "")
 
 	if config.Dev.Sync == nil || len(config.Dev.Sync) == 0 {
 		log.Info("No sync paths are configured. Run `devspace add sync` to add new sync path\n")

--- a/cmd/list/vars.go
+++ b/cmd/list/vars.go
@@ -45,10 +45,10 @@ func (cmd *varsCmd) RunListVars(cobraCmd *cobra.Command, args []string) {
 	}
 
 	// Fill variables config
-	configutil.GetConfig(context.Background())
+	configutil.GetConfig(context.Background(), "")
 
 	// Load generated config
-	generatedConfig, err := generated.LoadConfig(context.Background())
+	generatedConfig, err := generated.LoadConfig("")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -6,6 +6,7 @@ import (
 	"github.com/devspace-cloud/devspace/pkg/devspace/cloud"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/configutil"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/constants"
+	"github.com/devspace-cloud/devspace/pkg/devspace/config/generated"
 	latest "github.com/devspace-cloud/devspace/pkg/devspace/config/versions/latest"
 	"github.com/devspace-cloud/devspace/pkg/devspace/kubectl"
 	"github.com/devspace-cloud/devspace/pkg/devspace/services"
@@ -68,9 +69,18 @@ devspace logs --namespace=mynamespace
 // RunLogs executes the functionality devspace logs
 func (cmd *LogsCmd) RunLogs(cobraCmd *cobra.Command, args []string) {
 	// Set config root
-	_, err := configutil.SetDevSpaceRoot()
+	configExists, err := configutil.SetDevSpaceRoot()
 	if err != nil {
 		log.Fatal(err)
+	}
+
+	// Load generated config if possible
+	var generatedConfig *generated.Config
+	if configExists {
+		generatedConfig, err = generated.LoadConfig("")
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 
 	// Get kubectl client
@@ -79,7 +89,7 @@ func (cmd *LogsCmd) RunLogs(cobraCmd *cobra.Command, args []string) {
 		log.Fatalf("Unable to create new kubectl client: %v", err)
 	}
 
-	err = client.PrintWarning(context.Background(), false, log.GetInstance())
+	err = client.PrintWarning(generatedConfig, false, log.GetInstance())
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -92,7 +102,7 @@ func (cmd *LogsCmd) RunLogs(cobraCmd *cobra.Command, args []string) {
 
 	var config *latest.Config
 	if configutil.ConfigExists() {
-		config = configutil.GetConfig(context.WithValue(context.Background(), constants.KubeContextKey, client.CurrentContext))
+		config = configutil.GetConfig(context.WithValue(context.Background(), constants.KubeContextKey, client.CurrentContext), "")
 	}
 
 	// Build params

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -93,13 +93,22 @@ func (cmd *OpenCmd) RunOpen(cobraCmd *cobra.Command, args []string) {
 		ingressControllerWarning = ""
 	)
 
+	// Load generated config if possible
+	var generatedConfig *generated.Config
+	if configExists {
+		generatedConfig, err = generated.LoadConfig("")
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
 	// Get kubernetes client
 	client, err := kubectl.NewClientFromContext(cmd.KubeContext, cmd.Namespace, false)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	err = client.PrintWarning(context.Background(), false, log.GetInstance())
+	err = client.PrintWarning(generatedConfig, false, log.GetInstance())
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -114,7 +123,7 @@ func (cmd *OpenCmd) RunOpen(cobraCmd *cobra.Command, args []string) {
 	var devspaceConfig *latest.Config
 	if configExists {
 		// Get config with adjusted cluster config
-		devspaceConfig = configutil.GetConfig(context.WithValue(context.Background(), constants.KubeContextKey, client.CurrentContext))
+		devspaceConfig = configutil.GetConfig(context.WithValue(context.Background(), constants.KubeContextKey, client.CurrentContext), "")
 	}
 
 	namespace := client.Namespace

--- a/cmd/purge.go
+++ b/cmd/purge.go
@@ -73,12 +73,7 @@ func (cmd *PurgeCmd) Run(cobraCmd *cobra.Command, args []string) {
 	log.StartFileLogging()
 
 	// Get config with adjusted cluster config
-	ctx := context.Background()
-	if cmd.Profile != "" {
-		ctx = context.WithValue(ctx, constants.ProfileContextKey, cmd.Profile)
-	}
-
-	generatedConfig, err := generated.LoadConfig(ctx)
+	generatedConfig, err := generated.LoadConfig(cmd.Profile)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -88,13 +83,13 @@ func (cmd *PurgeCmd) Run(cobraCmd *cobra.Command, args []string) {
 		log.Fatalf("Unable to create new kubectl client: %v", err)
 	}
 
-	err = client.PrintWarning(ctx, false, log.GetInstance())
+	err = client.PrintWarning(generatedConfig, false, log.GetInstance())
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	// Add kube context to context
-	context.WithValue(ctx, constants.KubeContextKey, client.CurrentContext)
+	ctx := context.WithValue(context.Background(), constants.KubeContextKey, client.CurrentContext)
 
 	// Signal that we are working on the space if there is any
 	err = cloud.ResumeSpace(client, true, log.GetInstance())
@@ -103,7 +98,7 @@ func (cmd *PurgeCmd) Run(cobraCmd *cobra.Command, args []string) {
 	}
 
 	// Get config with adjusted cluster config
-	config := configutil.GetConfig(ctx)
+	config := configutil.GetConfig(ctx, cmd.Profile)
 
 	deployments := []string{}
 	if cmd.Deployments != "" {

--- a/cmd/purge.go
+++ b/cmd/purge.go
@@ -20,6 +20,7 @@ import (
 type PurgeCmd struct {
 	Deployments             string
 	AllowCyclicDependencies bool
+	VerboseDependencies     bool
 	PurgeDependencies       bool
 
 	Namespace   string
@@ -55,6 +56,7 @@ devspace purge -d my-deployment
 	purgeCmd.Flags().StringVarP(&cmd.Deployments, "deployments", "d", "", "The deployment to delete (You can specify multiple deployments comma-separated, e.g. devspace-default,devspace-database etc.)")
 	purgeCmd.Flags().BoolVar(&cmd.AllowCyclicDependencies, "allow-cyclic", false, "When enabled allows cyclic dependencies")
 	purgeCmd.Flags().BoolVar(&cmd.PurgeDependencies, "dependencies", false, "When enabled purges the dependencies as well")
+	purgeCmd.Flags().BoolVar(&cmd.VerboseDependencies, "verbose-dependencies", false, "Builds the dependencies verbosely")
 
 	return purgeCmd
 }
@@ -113,7 +115,7 @@ func (cmd *PurgeCmd) Run(cobraCmd *cobra.Command, args []string) {
 
 	// Purge dependencies
 	if cmd.PurgeDependencies {
-		err = dependency.PurgeAll(config, generatedConfig, client, cmd.AllowCyclicDependencies, log.GetInstance())
+		err = dependency.PurgeAll(config, generatedConfig, client, cmd.AllowCyclicDependencies, cmd.VerboseDependencies, log.GetInstance())
 		if err != nil {
 			log.Errorf("Error purging dependencies: %v", err)
 		}

--- a/cmd/remove/deployment.go
+++ b/cmd/remove/deployment.go
@@ -82,7 +82,7 @@ func (cmd *deploymentCmd) RunRemoveDeployment(cobraCmd *cobra.Command, args []st
 			deployments = []string{args[0]}
 		}
 
-		generatedConfig, err := generated.LoadConfig(context.Background())
+		generatedConfig, err := generated.LoadConfig("")
 		if err != nil {
 			log.Errorf("Error loading generated.yaml: %v", err)
 			return

--- a/cmd/remove/space.go
+++ b/cmd/remove/space.go
@@ -1,7 +1,6 @@
 package remove
 
 import (
-	"context"
 	"strconv"
 
 	cloudpkg "github.com/devspace-cloud/devspace/pkg/devspace/cloud"
@@ -132,7 +131,7 @@ func (cmd *spaceCmd) RunRemoveCloudDevSpace(cobraCmd *cobra.Command, args []stri
 
 	if configExists {
 		// Get current space
-		generatedConfig, err := generated.LoadConfig(context.Background())
+		generatedConfig, err := generated.LoadConfig("")
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/reset/vars.go
+++ b/cmd/reset/vars.go
@@ -1,8 +1,6 @@
 package reset
 
 import (
-	"context"
-
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/configutil"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/generated"
 	"github.com/devspace-cloud/devspace/pkg/util/log"
@@ -47,7 +45,7 @@ func (cmd *varsCmd) RunResetVars(cobraCmd *cobra.Command, args []string) {
 	}
 
 	// Load generated config
-	generatedConfig, err := generated.LoadConfig(context.Background())
+	generatedConfig, err := generated.LoadConfig("")
 	if err != nil {
 		log.Fatalf("Error loading generated.yaml: %v", err)
 	}

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -6,6 +6,7 @@ import (
 	"github.com/devspace-cloud/devspace/pkg/devspace/cloud"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/configutil"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/constants"
+	"github.com/devspace-cloud/devspace/pkg/devspace/config/generated"
 	latest "github.com/devspace-cloud/devspace/pkg/devspace/config/versions/latest"
 	"github.com/devspace-cloud/devspace/pkg/devspace/kubectl"
 	"github.com/devspace-cloud/devspace/pkg/devspace/services"
@@ -71,13 +72,23 @@ devspace sync --container-path=/my-path
 
 // Run executes the command logic
 func (cmd *SyncCmd) Run(cobraCmd *cobra.Command, args []string) {
+	// Load generated config if possible
+	var err error
+	var generatedConfig *generated.Config
+	if configutil.ConfigExists() {
+		generatedConfig, err = generated.LoadConfig("")
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
 	// Get config with adjusted cluster config
 	client, err := kubectl.NewClientFromContext(cmd.KubeContext, cmd.Namespace, false)
 	if err != nil {
 		log.Fatalf("Unable to create new kubectl client: %v", err)
 	}
 
-	err = client.PrintWarning(context.Background(), false, log.GetInstance())
+	err = client.PrintWarning(generatedConfig, false, log.GetInstance())
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -90,7 +101,7 @@ func (cmd *SyncCmd) Run(cobraCmd *cobra.Command, args []string) {
 
 	var config *latest.Config
 	if configutil.ConfigExists() {
-		config = configutil.GetConfig(context.WithValue(context.Background(), constants.KubeContextKey, client.CurrentContext))
+		config = configutil.GetConfig(context.WithValue(context.Background(), constants.KubeContextKey, client.CurrentContext), "")
 	}
 
 	// Build params

--- a/cmd/update/dependencies.go
+++ b/cmd/update/dependencies.go
@@ -52,10 +52,10 @@ func (cmd *dependenciesCmd) RunDependencies(cobraCmd *cobra.Command, args []stri
 	}
 
 	// Get the config
-	config := configutil.GetConfig(context.Background())
+	config := configutil.GetConfig(context.Background(), "")
 
 	// Load generated config
-	generatedConfig, err := generated.LoadConfig(context.Background())
+	generatedConfig, err := generated.LoadConfig("")
 	if err != nil {
 		log.Fatalf("Error loading generated.yaml: %v", err)
 	}

--- a/cmd/use/context.go
+++ b/cmd/use/context.go
@@ -1,8 +1,6 @@
 package use
 
 import (
-	contextpkg "context"
-
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/configutil"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/generated"
 	"github.com/devspace-cloud/devspace/pkg/util/kubeconfig"
@@ -82,7 +80,7 @@ func (cmd *contextCmd) RunUseContext(cobraCmd *cobra.Command, args []string) {
 
 		if configExists {
 			// Get generated config
-			generatedConfig, err := generated.LoadConfig(contextpkg.Background())
+			generatedConfig, err := generated.LoadConfig("")
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/cmd/use/namespace.go
+++ b/cmd/use/namespace.go
@@ -1,8 +1,6 @@
 package use
 
 import (
-	"context"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/configutil"
@@ -118,7 +116,7 @@ func (cmd *namespaceCmd) RunUseNamespace(cobraCmd *cobra.Command, args []string)
 
 	if configExists {
 		// Get generated config
-		generatedConfig, err := generated.LoadConfig(context.Background())
+		generatedConfig, err := generated.LoadConfig("")
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/use/profile.go
+++ b/cmd/use/profile.go
@@ -1,8 +1,6 @@
 package use
 
 import (
-	"context"
-
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/configutil"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/generated"
 
@@ -83,7 +81,7 @@ func (cmd *profileCmd) RunUseProfile(cobraCmd *cobra.Command, args []string) {
 	}
 
 	// Load generated config
-	generatedConfig, err := generated.LoadConfig(context.Background())
+	generatedConfig, err := generated.LoadConfig("")
 	if err != nil {
 		log.Fatalf("Cannot load generated config: %v", err)
 	}

--- a/cmd/use/space.go
+++ b/cmd/use/space.go
@@ -1,7 +1,6 @@
 package use
 
 import (
-	"context"
 	"strconv"
 
 	"github.com/devspace-cloud/devspace/pkg/devspace/cloud"
@@ -179,7 +178,7 @@ func (cmd *spaceCmd) RunUseSpace(cobraCmd *cobra.Command, args []string) {
 		}
 
 		// Get generated config
-		generatedConfig, err := generated.LoadConfig(context.Background())
+		generatedConfig, err := generated.LoadConfig("")
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/examples/redeploy-instead-of-hot-reload/main.go
+++ b/examples/redeploy-instead-of-hot-reload/main.go
@@ -8,6 +8,6 @@ import (
 func main() {
 	for {
 		fmt.Println("Hello World!")
-		time.Sleep(time.Second)
+		time.Sleep(time.Second * 5)
 	}
 }

--- a/pkg/devspace/build/build.go
+++ b/pkg/devspace/build/build.go
@@ -93,6 +93,10 @@ func All(config *latest.Config, cache *generated.CacheConfig, client *kubectl.Cl
 
 			// Update cache
 			imageCache := cache.GetImageCache(imageConfigName)
+			if imageCache.Tag == imageTag {
+				log.Warnf("Newly built image '%s' has the same tag as in the last build (%s), this can lead to problems that the image during deployment is not updated", imageName, imageTag)
+			}
+
 			imageCache.ImageName = imageName
 			imageCache.Tag = imageTag
 
@@ -137,6 +141,10 @@ func All(config *latest.Config, cache *generated.CacheConfig, client *kubectl.Cl
 
 				// Update cache
 				imageCache := cache.GetImageCache(done.imageConfigName)
+				if imageCache.Tag == done.imageTag {
+					log.Warnf("Newly built image '%s' has the same tag as in the last build (%s), this can lead to problems that the image during deployment is not updated", done.imageName, done.imageTag)
+				}
+
 				imageCache.ImageName = done.imageName
 				imageCache.Tag = done.imageTag
 

--- a/pkg/devspace/build/build.go
+++ b/pkg/devspace/build/build.go
@@ -21,7 +21,7 @@ type imageNameAndTag struct {
 }
 
 // All builds all images
-func All(config *latest.Config, cache *generated.CacheConfig, client *kubectl.Client, skipPush, isDev, forceRebuild, sequential bool, log logpkg.Logger) (map[string]string, error) {
+func All(config *latest.Config, cache *generated.CacheConfig, client *kubectl.Client, skipPush, isDev, forceRebuild, sequential, skipBuildIfAlreadyBuilt bool, log logpkg.Logger) (map[string]string, error) {
 	var (
 		builtImages = make(map[string]string)
 
@@ -78,7 +78,9 @@ func All(config *latest.Config, cache *generated.CacheConfig, client *kubectl.Cl
 		if err != nil {
 			return nil, fmt.Errorf("Error during shouldRebuild check: %v", err)
 		}
-		if forceRebuild == false && needRebuild == false {
+
+		imageCache := cache.GetImageCache(imageConfigName)
+		if forceRebuild == false && (needRebuild == false || (skipBuildIfAlreadyBuilt && imageCache.Tag != "")) {
 			log.Infof("Skip building image '%s'", imageConfigName)
 			continue
 		}

--- a/pkg/devspace/builder/docker/docker.go
+++ b/pkg/devspace/builder/docker/docker.go
@@ -175,7 +175,7 @@ func (b *Builder) BuildImage(contextPath, dockerfilePath string, entrypoint []st
 
 	// Check if we should overwrite entrypoint
 	if entrypoint != nil && len(entrypoint) > 0 {
-		dockerfilePath, err = helper.CreateTempDockerfile(dockerfilePath, entrypoint)
+		dockerfilePath, err = helper.CreateTempDockerfile(dockerfilePath, entrypoint, options.Target)
 		if err != nil {
 			return err
 		}

--- a/pkg/devspace/builder/helper/helper.go
+++ b/pkg/devspace/builder/helper/helper.go
@@ -107,11 +107,6 @@ func (b *BuildHelper) Build(imageBuilder BuildHelperInterface, log log.Logger) e
 func (b *BuildHelper) ShouldRebuild(cache *generated.CacheConfig) (bool, error) {
 	imageCache := cache.GetImageCache(b.ImageConfigName)
 
-	// In devspace dev we only rebuild if we are forced to or no cache exists
-	if b.IsDev && imageCache.Tag != "" {
-		return false, nil
-	}
-
 	// Hash dockerfile
 	_, err := os.Stat(b.DockerfilePath)
 	if err != nil {

--- a/pkg/devspace/builder/kaniko/kaniko.go
+++ b/pkg/devspace/builder/kaniko/kaniko.go
@@ -133,16 +133,6 @@ func (b *Builder) createPullSecret(log logpkg.Logger) error {
 func (b *Builder) BuildImage(contextPath, dockerfilePath string, entrypoint []string, log logpkg.Logger) error {
 	var err error
 
-	// Check if we should overwrite entrypoint
-	if entrypoint != nil && len(entrypoint) > 0 {
-		dockerfilePath, err = helper.CreateTempDockerfile(dockerfilePath, entrypoint)
-		if err != nil {
-			return err
-		}
-
-		defer os.RemoveAll(filepath.Dir(dockerfilePath))
-	}
-
 	// Buildoptions
 	options := &types.ImageBuildOptions{}
 	if b.helper.ImageConf.Build != nil && b.helper.ImageConf.Build.Kaniko != nil && b.helper.ImageConf.Build.Kaniko.Options != nil {
@@ -155,6 +145,16 @@ func (b *Builder) BuildImage(contextPath, dockerfilePath string, entrypoint []st
 		if b.helper.ImageConf.Build.Kaniko.Options.Network != "" {
 			options.NetworkMode = b.helper.ImageConf.Build.Kaniko.Options.Network
 		}
+	}
+
+	// Check if we should overwrite entrypoint
+	if entrypoint != nil && len(entrypoint) > 0 {
+		dockerfilePath, err = helper.CreateTempDockerfile(dockerfilePath, entrypoint, options.Target)
+		if err != nil {
+			return err
+		}
+
+		defer os.RemoveAll(filepath.Dir(dockerfilePath))
 	}
 
 	// Generate the build pod spec

--- a/pkg/devspace/config/configutil/get.go
+++ b/pkg/devspace/config/configutil/get.go
@@ -97,7 +97,7 @@ func GetConfigFromPath(ctx context.Context, generatedConfig *generated.Config, b
 		// Check for legacy devspace-configs.yaml
 		_, err = os.Stat(filepath.Join(basePath, constants.DefaultConfigsPath))
 		if err == nil {
-			return nil, fmt.Errorf("devspace-configs.yaml is not supported anymore in devspace v4. Please use the new config option 'configs' in 'devspace.yaml'")
+			return nil, fmt.Errorf("devspace-configs.yaml is not supported anymore in devspace v4. Please use 'profiles' in 'devspace.yaml' instead")
 		}
 
 		return nil, fmt.Errorf("Couldn't find '%s': %v", err)

--- a/pkg/devspace/config/configutil/get.go
+++ b/pkg/devspace/config/configutil/get.go
@@ -24,6 +24,7 @@ var config *latest.Config // merged config
 
 // Thread-safety helper
 var getConfigOnce sync.Once
+var getConfigOnceMutex sync.Mutex
 
 // ConfigExists checks whether the yaml file for the config exists or the configs.yaml exists
 func ConfigExists() bool {
@@ -52,8 +53,19 @@ func configExistsInPath(path string) bool {
 	return false // Normal config file found
 }
 
+// ResetConfig resets the current config
+func ResetConfig() {
+	getConfigOnceMutex.Lock()
+	defer getConfigOnceMutex.Unlock()
+
+	getConfigOnce = sync.Once{}
+}
+
 // InitConfig initializes the config objects
 func InitConfig() *latest.Config {
+	getConfigOnceMutex.Lock()
+	defer getConfigOnceMutex.Unlock()
+
 	getConfigOnce.Do(func() {
 		config = latest.New().(*latest.Config)
 	})
@@ -63,20 +75,20 @@ func InitConfig() *latest.Config {
 
 // GetBaseConfig returns the config
 func GetBaseConfig(ctx context.Context) *latest.Config {
-	loadConfigOnce(ctx, false)
+	loadConfigOnce(ctx, "", false)
 
 	return config
 }
 
 // GetConfig returns the config merged with all potential overwrite files
-func GetConfig(ctx context.Context) *latest.Config {
-	loadConfigOnce(ctx, true)
+func GetConfig(ctx context.Context, profile string) *latest.Config {
+	loadConfigOnce(ctx, profile, true)
 
 	return config
 }
 
 // GetConfigFromPath loads the config from a given base path
-func GetConfigFromPath(ctx context.Context, generatedConfig *generated.Config, basePath string, log log.Logger) (*latest.Config, error) {
+func GetConfigFromPath(ctx context.Context, generatedConfig *generated.Config, basePath string, profile string, log log.Logger) (*latest.Config, error) {
 	configPath := filepath.Join(basePath, constants.DefaultConfigPath)
 
 	// Check devspace.yaml
@@ -102,7 +114,7 @@ func GetConfigFromPath(ctx context.Context, generatedConfig *generated.Config, b
 		return nil, err
 	}
 
-	loadedConfig, err := ParseConfig(ctx, generatedConfig, rawMap)
+	loadedConfig, err := ParseConfig(ctx, generatedConfig, rawMap, profile)
 	if err != nil {
 		return nil, err
 	}
@@ -133,23 +145,26 @@ func GetConfigFromPath(ctx context.Context, generatedConfig *generated.Config, b
 }
 
 // loadConfigOnce loads the config globally once
-func loadConfigOnce(ctx context.Context, allowProfile bool) *latest.Config {
+func loadConfigOnce(ctx context.Context, profile string, allowProfile bool) *latest.Config {
+	getConfigOnceMutex.Lock()
+	defer getConfigOnceMutex.Unlock()
+
 	getConfigOnce.Do(func() {
 		// Get generated config
-		generatedConfig, err := generated.LoadConfig(ctx)
+		generatedConfig, err := generated.LoadConfig(profile)
 		if err != nil {
 			log.Panicf("Error loading %s: %v", generated.ConfigPath, err)
 		}
 
 		// Check if we should load a specific config
-		if allowProfile && generatedConfig.ActiveProfile != "" && ctx.Value(constants.ProfileContextKey) == nil {
-			ctx = context.WithValue(ctx, constants.ProfileContextKey, generatedConfig.ActiveProfile)
+		if allowProfile && generatedConfig.ActiveProfile != "" && profile == "" {
+			profile = generatedConfig.ActiveProfile
 		} else if !allowProfile {
-			ctx = context.WithValue(ctx, constants.ProfileContextKey, nil)
+			profile = ""
 		}
 
 		// Load base config
-		config, err = GetConfigFromPath(ctx, generatedConfig, ".", log.GetInstance())
+		config, err = GetConfigFromPath(ctx, generatedConfig, ".", profile, log.GetInstance())
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/pkg/devspace/config/configutil/parse.go
+++ b/pkg/devspace/config/configutil/parse.go
@@ -66,7 +66,7 @@ func GetProfiles(basePath string) ([]string, error) {
 }
 
 // ParseConfig fills the variables in the data and parses the config
-func ParseConfig(ctx context.Context, generatedConfig *generated.Config, data map[interface{}]interface{}) (*latest.Config, error) {
+func ParseConfig(ctx context.Context, generatedConfig *generated.Config, data map[interface{}]interface{}, profile string) (*latest.Config, error) {
 	// Load defined variables
 	vars, err := versions.ParseVariables(data)
 	if err != nil {
@@ -74,7 +74,7 @@ func ParseConfig(ctx context.Context, generatedConfig *generated.Config, data ma
 	}
 
 	// Prepare config for variable loading
-	preparedConfig, err := versions.Prepare(ctx, data)
+	preparedConfig, err := versions.Prepare(data, profile)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/devspace/config/constants/constants.go
+++ b/pkg/devspace/config/constants/constants.go
@@ -20,6 +20,3 @@ const DevSpaceCloudNamespace = "devspace-cloud"
 
 // KubeContextKey is used in contexts
 const KubeContextKey = "kubecontext"
-
-// ProfileContextKey is used in contexts
-const ProfileContextKey = "profile"

--- a/pkg/devspace/config/generated/config.go
+++ b/pkg/devspace/config/generated/config.go
@@ -1,14 +1,11 @@
 package generated
 
 import (
-	"context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
 
-	"github.com/devspace-cloud/devspace/pkg/devspace/config/constants"
-	"github.com/devspace-cloud/devspace/pkg/util/ptr"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -73,18 +70,18 @@ func SetTestConfig(config *Config) {
 }
 
 // LoadConfig loads the config from the filesystem
-func LoadConfig(ctx context.Context) (*Config, error) {
+func LoadConfig(profile string) (*Config, error) {
 	var err error
 
 	loadedConfigOnce.Do(func() {
-		loadedConfig, err = LoadConfigFromPath(ctx, ConfigPath)
+		loadedConfig, err = LoadConfigFromPath(ConfigPath, profile)
 	})
 
 	return loadedConfig, err
 }
 
 // LoadConfigFromPath loads the generated config from a given path
-func LoadConfigFromPath(ctx context.Context, path string) (*Config, error) {
+func LoadConfigFromPath(path, profile string) (*Config, error) {
 	var loadedConfig *Config
 
 	data, readErr := ioutil.ReadFile(path)
@@ -111,8 +108,8 @@ func LoadConfigFromPath(ctx context.Context, path string) (*Config, error) {
 	}
 
 	// Set override profile
-	if ctx.Value(constants.ProfileContextKey) != nil && ctx.Value(constants.ProfileContextKey).(string) != "" {
-		loadedConfig.OverrideProfile = ptr.String(ctx.Value(constants.ProfileContextKey).(string))
+	if profile != "" {
+		loadedConfig.OverrideProfile = &profile
 	} else {
 		loadedConfig.OverrideProfile = nil
 	}

--- a/pkg/devspace/config/versions/config/interface.go
+++ b/pkg/devspace/config/versions/config/interface.go
@@ -1,7 +1,5 @@
 package config
 
-import "context"
-
 // Config is the interface for each config version
 type Config interface {
 	GetVersion() string
@@ -15,4 +13,4 @@ type New func() Config
 type Variables func(data map[interface{}]interface{}) (map[interface{}]interface{}, error)
 
 // Prepare prepares a config for variable loading and strips unused configuration
-type Prepare func(ctx context.Context, data map[interface{}]interface{}) (map[interface{}]interface{}, error)
+type Prepare func(data map[interface{}]interface{}, profile string) (map[interface{}]interface{}, error)

--- a/pkg/devspace/config/versions/latest/load.go
+++ b/pkg/devspace/config/versions/latest/load.go
@@ -1,10 +1,8 @@
 package latest
 
 import (
-	"context"
 	"fmt"
 
-	"github.com/devspace-cloud/devspace/pkg/devspace/config/constants"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/versions/util"
 )
 
@@ -23,7 +21,7 @@ func Variables(data map[interface{}]interface{}) (map[interface{}]interface{}, e
 }
 
 // Prepare prepares the given config for variable loading
-func Prepare(ctx context.Context, data map[interface{}]interface{}) (map[interface{}]interface{}, error) {
+func Prepare(data map[interface{}]interface{}, profile string) (map[interface{}]interface{}, error) {
 	loaded := map[interface{}]interface{}{}
 	err := util.Convert(data, &loaded)
 	if err != nil {
@@ -33,12 +31,7 @@ func Prepare(ctx context.Context, data map[interface{}]interface{}) (map[interfa
 	// Delete vars definition
 	delete(loaded, "vars")
 
-	config := ""
-	if ctx.Value(constants.ProfileContextKey) != nil {
-		config = ctx.Value(constants.ProfileContextKey).(string)
-	}
-
-	if config == "" {
+	if profile == "" {
 		delete(loaded, "profiles")
 		return loaded, nil
 	}
@@ -46,18 +39,18 @@ func Prepare(ctx context.Context, data map[interface{}]interface{}) (map[interfa
 	// Convert to array
 	profiles, ok := loaded["profiles"].([]interface{})
 	if !ok {
-		return nil, fmt.Errorf("Couldn't load profile '%s': no profiles found", config)
+		return nil, fmt.Errorf("Couldn't load profile '%s': no profiles found", profile)
 	}
 
 	// Search for config
 	for _, profileMap := range profiles {
 		configMap, ok := profileMap.(map[interface{}]interface{})
-		if ok && configMap["name"] == config {
+		if ok && configMap["name"] == profile {
 			loaded["profiles"] = []interface{}{profileMap}
 			return loaded, nil
 		}
 	}
 
 	// Couldn't find config
-	return nil, fmt.Errorf("Couldn't find profile '%s'", config)
+	return nil, fmt.Errorf("Couldn't find profile '%s'", profile)
 }

--- a/pkg/devspace/config/versions/versions.go
+++ b/pkg/devspace/config/versions/versions.go
@@ -1,7 +1,6 @@
 package versions
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/versions/config"
@@ -35,7 +34,7 @@ var versionLoader = map[string]*loader{
 }
 
 // Prepare prepares the config for variable loading
-func Prepare(ctx context.Context, data map[interface{}]interface{}) (map[interface{}]interface{}, error) {
+func Prepare(data map[interface{}]interface{}, profile string) (map[interface{}]interface{}, error) {
 	version, ok := data["version"].(string)
 	if ok == false {
 		// This is needed because overrides usually don't have versions
@@ -59,7 +58,7 @@ func Prepare(ctx context.Context, data map[interface{}]interface{}) (map[interfa
 		return cloned, nil
 	}
 
-	return prepareFunc(ctx, data)
+	return prepareFunc(data, profile)
 }
 
 // ParseVariables parses only the variables from the config

--- a/pkg/devspace/dependency/dependency.go
+++ b/pkg/devspace/dependency/dependency.go
@@ -267,7 +267,7 @@ func (d *Dependency) Build(skipPush, forceDependencies, forceBuild bool, log log
 	builtImages := make(map[string]string)
 	if d.DependencyConfig.SkipBuild == nil || *d.DependencyConfig.SkipBuild == false {
 		// Build images
-		builtImages, err = build.All(d.Config, d.GeneratedConfig.GetActive(), nil, skipPush, false, forceBuild, false, log)
+		builtImages, err = build.All(d.Config, d.GeneratedConfig.GetActive(), nil, skipPush, false, forceBuild, false, false, log)
 		if err != nil {
 			return err
 		}
@@ -344,7 +344,7 @@ func (d *Dependency) Deploy(client *kubectl.Client, skipPush, forceDependencies,
 	builtImages := make(map[string]string)
 	if skipBuild == false && (d.DependencyConfig.SkipBuild == nil || *d.DependencyConfig.SkipBuild == false) {
 		// Build images
-		builtImages, err = build.All(d.Config, d.GeneratedConfig.GetActive(), client, skipPush, false, forceBuild, false, log)
+		builtImages, err = build.All(d.Config, d.GeneratedConfig.GetActive(), client, skipPush, false, forceBuild, false, false, log)
 		if err != nil {
 			return err
 		}

--- a/pkg/devspace/dependency/resolver.go
+++ b/pkg/devspace/dependency/resolver.go
@@ -80,8 +80,7 @@ func NewResolver(baseConfig *latest.Config, baseCache *generated.Config, allowCy
 
 // Resolve implements interface
 func (r *Resolver) Resolve(ctx context.Context, dependencies []*latest.DependencyConfig, update bool) ([]*Dependency, error) {
-	r.log.StartWait("Resolving dependencies")
-	defer r.log.StopWait()
+	r.log.Info("Start resolving dependencies")
 
 	currentWorkingDirectory, err := os.Getwd()
 	if err != nil {
@@ -97,8 +96,14 @@ func (r *Resolver) Resolve(ctx context.Context, dependencies []*latest.Dependenc
 		return nil, errors.Wrap(err, "resolve dependencies recursive")
 	}
 
-	r.log.StopWait()
 	r.log.Donef("Resolved %d dependencies", len(r.DependencyGraph.Nodes)-1)
+
+	// Save generated
+	err = generated.SaveConfig(r.BaseCache)
+	if err != nil {
+		return nil, err
+	}
+
 	return r.buildDependencyQueue()
 }
 

--- a/pkg/devspace/dependency/resolver.go
+++ b/pkg/devspace/dependency/resolver.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/configutil"
-	"github.com/devspace-cloud/devspace/pkg/devspace/config/constants"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/generated"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/versions/latest"
 	"github.com/devspace-cloud/devspace/pkg/util/git"
@@ -216,15 +215,12 @@ func (r *Resolver) resolveDependency(ctx context.Context, basePath string, depen
 		}
 	}
 
-	// Set profile to load
-	ctx = context.WithValue(ctx, constants.ProfileContextKey, dependency.Profile)
-
 	if dependency.Source.SubPath != "" {
 		localPath = filepath.Join(localPath, filepath.FromSlash(dependency.Source.SubPath))
 	}
 
 	// Load config
-	dConfig, err := configutil.GetConfigFromPath(ctx, r.BaseCache, localPath, log.Discard)
+	dConfig, err := configutil.GetConfigFromPath(ctx, r.BaseCache, localPath, dependency.Profile, log.Discard)
 	if err != nil {
 		return nil, fmt.Errorf("Error loading config for dependency %s: %v", ID, err)
 	}
@@ -233,7 +229,7 @@ func (r *Resolver) resolveDependency(ctx context.Context, basePath string, depen
 	dConfig.Dev = &latest.DevConfig{}
 
 	// Load dependency generated config
-	dGeneratedConfig, err := generated.LoadConfigFromPath(ctx, filepath.Join(localPath, filepath.FromSlash(generated.ConfigPath)))
+	dGeneratedConfig, err := generated.LoadConfigFromPath(filepath.Join(localPath, filepath.FromSlash(generated.ConfigPath)), dependency.Profile)
 	if err != nil {
 		return nil, fmt.Errorf("Error loading generated config for dependency %s: %v", ID, err)
 	}

--- a/pkg/devspace/kubectl/client.go
+++ b/pkg/devspace/kubectl/client.go
@@ -1,7 +1,6 @@
 package kubectl
 
 import (
-	"context"
 	"fmt"
 	"net"
 	"net/url"
@@ -141,9 +140,8 @@ func NewClientBySelect(allowPrivate bool, switchContext bool) (*Client, error) {
 }
 
 // PrintWarning prints a warning if the last kube context is different than this one
-func (client *Client) PrintWarning(ctx context.Context, updateGenerated bool, log log.Logger) error {
-	generatedConfig, err := generated.LoadConfig(ctx)
-	if err == nil {
+func (client *Client) PrintWarning(generatedConfig *generated.Config, updateGenerated bool, log log.Logger) error {
+	if generatedConfig != nil {
 		// print warning if context or namespace has changed since last deployment process (expect if explicitly provided as flags)
 		if generatedConfig.GetActive().LastContext != nil {
 			wait := false

--- a/pkg/devspace/sync/symlink.go
+++ b/pkg/devspace/sync/symlink.go
@@ -50,7 +50,7 @@ func NewSymlink(upstream *upstream, symlinkPath, targetPath string, isDir bool) 
 		watchPath += "/**"
 	}
 
-	watcher, err := watch.New([]string{watchPath}, symlink.handleChange, log.Discard)
+	watcher, err := watch.New([]string{watchPath}, []string{}, symlink.handleChange, log.Discard)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR includes:
- Refactoring of config loading
- Print a warning if old tag is the same as new tag
- Don't rebuild images in dev if there is already a built image
- Add '--verbose-dependencies' flag (#664)
- Overriding docker entrypoints now also works with multi staged builds