### PR TITLE
trim space (especially \r) for sync ignoreRules

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -379,7 +379,7 @@ func (cmd *InitCmd) addDevConfig() error {
 				dockerignoreRules := strings.Split(string(dockerignore), "\n")
 				for _, ignoreRule := range dockerignoreRules {
 					if len(ignoreRule) > 0 && ignoreRule[0] != "#"[0] {
-						excludePaths = append(excludePaths, ignoreRule)
+						excludePaths = append(excludePaths, strings.TrimSpace(ignoreRule))
 					}
 				}
 			}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -378,8 +378,9 @@ func (cmd *InitCmd) addDevConfig() error {
 			if err == nil {
 				dockerignoreRules := strings.Split(string(dockerignore), "\n")
 				for _, ignoreRule := range dockerignoreRules {
+					ignoreRule = strings.TrimSpace(ignoreRule)
 					if len(ignoreRule) > 0 && ignoreRule[0] != "#"[0] {
-						excludePaths = append(excludePaths, strings.TrimSpace(ignoreRule))
+						excludePaths = append(excludePaths, ignoreRule)
 					}
 				}
 			}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others)  
/kind enhancement


**What is this pull request for? Which issues does it resolve?** (use `resolves #<issue_number>` if possible)  
When users are using `\r\n` newlines in .dockerignore, `devspace init` will add `\r` to the sync ignore rules. This fixes it.
