### PR TITLE
Refactor

### DIFF
--- a/cmd/add/deployment.go
+++ b/cmd/add/deployment.go
@@ -83,7 +83,7 @@ devspace add deployment my-deployment --manifests=kube/* --namespace=devspace
 // RunAddDeployment executes the add deployment command logic
 func (cmd *deploymentCmd) RunAddDeployment(cobraCmd *cobra.Command, args []string) error {
 	// Set config root
-	configExists, err := configutil.SetDevSpaceRoot()
+	configExists, err := configutil.SetDevSpaceRoot(log.GetInstance())
 	if err != nil {
 		return err
 	}

--- a/cmd/add/image.go
+++ b/cmd/add/image.go
@@ -57,7 +57,7 @@ devspace add image my-image --image=dockeruser/devspaceimage2 --buildtool=kaniko
 // RunAddImage executes the add image command logic
 func (cmd *imageCmd) RunAddImage(cobraCmd *cobra.Command, args []string) error {
 	// Set config root
-	configExists, err := configutil.SetDevSpaceRoot()
+	configExists, err := configutil.SetDevSpaceRoot(log.GetInstance())
 	if err != nil {
 		return err
 	}

--- a/cmd/add/port.go
+++ b/cmd/add/port.go
@@ -42,7 +42,7 @@ devspace add port 8080:80,3000
 // RunAddPort executes the add port command logic
 func (cmd *portCmd) RunAddPort(cobraCmd *cobra.Command, args []string) error {
 	// Set config root
-	configExists, err := configutil.SetDevSpaceRoot()
+	configExists, err := configutil.SetDevSpaceRoot(log.GetInstance())
 	if err != nil {
 		return err
 	}

--- a/cmd/add/sync.go
+++ b/cmd/add/sync.go
@@ -53,7 +53,7 @@ devspace add sync --local=app --container=/app
 // RunAddSync executes the add sync command logic
 func (cmd *syncCmd) RunAddSync(cobraCmd *cobra.Command, args []string) error {
 	// Set config root
-	configExists, err := configutil.SetDevSpaceRoot()
+	configExists, err := configutil.SetDevSpaceRoot(log.GetInstance())
 	if err != nil {
 		return err
 	}

--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -50,7 +50,7 @@ devspace analyze --namespace=mynamespace
 // RunAnalyze executes the functionality "devspace analyze"
 func (cmd *AnalyzeCmd) RunAnalyze(cobraCmd *cobra.Command, args []string) error {
 	// Set config root
-	configExists, err := configutil.SetDevSpaceRoot()
+	configExists, err := configutil.SetDevSpaceRoot(log.GetInstance())
 	if err != nil {
 		return err
 	}

--- a/cmd/attach.go
+++ b/cmd/attach.go
@@ -57,7 +57,7 @@ devspace attach -n my-namespace
 // Run executes the command logic
 func (cmd *AttachCmd) Run(cobraCmd *cobra.Command, args []string) error {
 	// Set config root
-	configExists, err := configutil.SetDevSpaceRoot()
+	configExists, err := configutil.SetDevSpaceRoot(log.GetInstance())
 	if err != nil {
 		return err
 	}

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -59,7 +59,7 @@ Builds all defined images and pushes them
 // Run executes the command logic
 func (cmd *BuildCmd) Run(cobraCmd *cobra.Command, args []string) error {
 	// Set config root
-	configExists, err := configutil.SetDevSpaceRoot()
+	configExists, err := configutil.SetDevSpaceRoot(log.GetInstance())
 	if err != nil {
 		return err
 	}

--- a/cmd/cleanup/images.go
+++ b/cmd/cleanup/images.go
@@ -41,7 +41,7 @@ Deletes all locally created docker images from docker
 // RunCleanupImages executes the cleanup images command logic
 func (cmd *imagesCmd) RunCleanupImages(cobraCmd *cobra.Command, args []string) error {
 	// Set config root
-	configExists, err := configutil.SetDevSpaceRoot()
+	configExists, err := configutil.SetDevSpaceRoot(log.GetInstance())
 	if err != nil {
 		return err
 	}

--- a/cmd/create/space.go
+++ b/cmd/create/space.go
@@ -51,7 +51,7 @@ devspace create space myspace
 // RunCreateSpace executes the "devspace create space" command logic
 func (cmd *spaceCmd) RunCreateSpace(cobraCmd *cobra.Command, args []string) error {
 	// Set config root
-	configExists, err := configutil.SetDevSpaceRoot()
+	configExists, err := configutil.SetDevSpaceRoot(log.GetInstance())
 	if err != nil {
 		return err
 	}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -75,7 +75,7 @@ devspace deploy --kube-context=deploy-context
 // Run executes the down command logic
 func (cmd *DeployCmd) Run(cobraCmd *cobra.Command, args []string) error {
 	// Set config root
-	configExists, err := configutil.SetDevSpaceRoot()
+	configExists, err := configutil.SetDevSpaceRoot(log.GetInstance())
 	if err != nil {
 		return err
 	}

--- a/cmd/dev.go
+++ b/cmd/dev.go
@@ -109,7 +109,7 @@ Use Interactive Mode:
 // Run executes the command logic
 func (cmd *DevCmd) Run(cobraCmd *cobra.Command, args []string) error {
 	// Set config root
-	configExists, err := configutil.SetDevSpaceRoot()
+	configExists, err := configutil.SetDevSpaceRoot(log.GetInstance())
 	if err != nil {
 		return err
 	}

--- a/cmd/enter.go
+++ b/cmd/enter.go
@@ -62,7 +62,7 @@ devspace enter bash -l release=test
 // Run executes the command logic
 func (cmd *EnterCmd) Run(cobraCmd *cobra.Command, args []string) error {
 	// Set config root
-	configExists, err := configutil.SetDevSpaceRoot()
+	configExists, err := configutil.SetDevSpaceRoot(log.GetInstance())
 	if err != nil {
 		return err
 	}

--- a/cmd/flags/flags.go
+++ b/cmd/flags/flags.go
@@ -32,7 +32,11 @@ func (gf *GlobalFlags) UseLastContext(generatedConfig *generated.Config, log log
 		return errors.Errorf("Flag --namespace cannot be used together with --switch-context")
 	}
 
-	if gf.SwitchContext == true && generatedConfig != nil && generatedConfig.GetActive().LastContext != nil {
+	if gf.SwitchContext == true {
+		if generatedConfig == nil || generatedConfig.GetActive().LastContext == nil {
+			return errors.Errorf("There is no last context to use. Only use the '--switch-context / -s' flag if you already have deployed the project before")
+		}
+
 		gf.KubeContext = generatedConfig.GetActive().LastContext.Context
 		gf.Namespace = generatedConfig.GetActive().LastContext.Namespace
 

--- a/cmd/list/commands.go
+++ b/cmd/list/commands.go
@@ -37,7 +37,7 @@ devspace.yaml
 // RunListCommands runs the list  command logic
 func (cmd *commandsCmd) RunListProfiles(cobraCmd *cobra.Command, args []string) error {
 	// Set config root
-	configExists, err := configutil.SetDevSpaceRoot()
+	configExists, err := configutil.SetDevSpaceRoot(log.GetInstance())
 	if err != nil {
 		return err
 	}

--- a/cmd/list/deployments.go
+++ b/cmd/list/deployments.go
@@ -41,7 +41,7 @@ Shows the status of all deployments
 // RunDeploymentsStatus executes the devspace status deployments command logic
 func (cmd *deploymentsCmd) RunDeploymentsStatus(cobraCmd *cobra.Command, args []string) error {
 	// Set config root
-	configExists, err := configutil.SetDevSpaceRoot()
+	configExists, err := configutil.SetDevSpaceRoot(log.GetInstance())
 	if err != nil {
 		return err
 	}

--- a/cmd/list/ports.go
+++ b/cmd/list/ports.go
@@ -37,7 +37,7 @@ Lists the port forwarding configurations
 // RunListPort runs the list port command logic
 func (cmd *portsCmd) RunListPort(cobraCmd *cobra.Command, args []string) error {
 	// Set config root
-	configExists, err := configutil.SetDevSpaceRoot()
+	configExists, err := configutil.SetDevSpaceRoot(log.GetInstance())
 	if err != nil {
 		return err
 	}

--- a/cmd/list/profiles.go
+++ b/cmd/list/profiles.go
@@ -36,7 +36,7 @@ Lists all DevSpace configuartions for this project
 // RunListProfiles runs the list profiles command logic
 func (cmd *profilesCmd) RunListProfiles(cobraCmd *cobra.Command, args []string) error {
 	// Set config root
-	configExists, err := configutil.SetDevSpaceRoot()
+	configExists, err := configutil.SetDevSpaceRoot(log.GetInstance())
 	if err != nil {
 		return err
 	}

--- a/cmd/list/sync.go
+++ b/cmd/list/sync.go
@@ -36,7 +36,7 @@ Lists the sync configuration
 // RunListSync runs the list sync command logic
 func (cmd *syncCmd) RunListSync(cobraCmd *cobra.Command, args []string) error {
 	// Set config root
-	configExists, err := configutil.SetDevSpaceRoot()
+	configExists, err := configutil.SetDevSpaceRoot(log.GetInstance())
 	if err != nil {
 		return err
 	}

--- a/cmd/list/vars.go
+++ b/cmd/list/vars.go
@@ -39,7 +39,7 @@ values
 // RunListVars runs the list vars command logic
 func (cmd *varsCmd) RunListVars(cobraCmd *cobra.Command, args []string) error {
 	// Set config root
-	configExists, err := configutil.SetDevSpaceRoot()
+	configExists, err := configutil.SetDevSpaceRoot(log.GetInstance())
 	if err != nil {
 		return err
 	}

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -62,7 +62,7 @@ devspace logs --namespace=mynamespace
 // RunLogs executes the functionality devspace logs
 func (cmd *LogsCmd) RunLogs(cobraCmd *cobra.Command, args []string) error {
 	// Set config root
-	configExists, err := configutil.SetDevSpaceRoot()
+	configExists, err := configutil.SetDevSpaceRoot(log.GetInstance())
 	if err != nil {
 		return err
 	}

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -73,7 +73,7 @@ devspace open
 // RunOpen executes the functionality "devspace open"
 func (cmd *OpenCmd) RunOpen(cobraCmd *cobra.Command, args []string) error {
 	// Set config root
-	configExists, err := configutil.SetDevSpaceRoot()
+	configExists, err := configutil.SetDevSpaceRoot(log.GetInstance())
 	if err != nil {
 		return err
 	}

--- a/cmd/purge.go
+++ b/cmd/purge.go
@@ -58,7 +58,7 @@ devspace purge -d my-deployment
 // Run executes the purge command logic
 func (cmd *PurgeCmd) Run(cobraCmd *cobra.Command, args []string) error {
 	// Set config root
-	configExists, err := configutil.SetDevSpaceRoot()
+	configExists, err := configutil.SetDevSpaceRoot(log.GetInstance())
 	if err != nil {
 		return err
 	}

--- a/cmd/remove/deployment.go
+++ b/cmd/remove/deployment.go
@@ -50,7 +50,7 @@ devspace remove deployment --all
 // RunRemoveDeployment executes the specified deployment
 func (cmd *deploymentCmd) RunRemoveDeployment(cobraCmd *cobra.Command, args []string) error {
 	// Set config root
-	configExists, err := configutil.SetDevSpaceRoot()
+	configExists, err := configutil.SetDevSpaceRoot(log.GetInstance())
 	if err != nil {
 		return err
 	}

--- a/cmd/remove/image.go
+++ b/cmd/remove/image.go
@@ -43,7 +43,7 @@ devspace remove image --all
 // RunRemoveImage executes the remove image command logic
 func (cmd *imageCmd) RunRemoveImage(cobraCmd *cobra.Command, args []string) error {
 	// Set config root
-	configExists, err := configutil.SetDevSpaceRoot()
+	configExists, err := configutil.SetDevSpaceRoot(log.GetInstance())
 	if err != nil {
 		return err
 	}

--- a/cmd/remove/port.go
+++ b/cmd/remove/port.go
@@ -46,7 +46,7 @@ devspace remove port --all
 // RunRemovePort executes the remove port command logic
 func (cmd *portCmd) RunRemovePort(cobraCmd *cobra.Command, args []string) error {
 	// Set config root
-	configExists, err := configutil.SetDevSpaceRoot()
+	configExists, err := configutil.SetDevSpaceRoot(log.GetInstance())
 	if err != nil {
 		return err
 	}

--- a/cmd/remove/space.go
+++ b/cmd/remove/space.go
@@ -52,7 +52,7 @@ devspace remove space --all
 // RunRemoveCloudDevSpace executes the devspace remove cloud devspace functionality
 func (cmd *spaceCmd) RunRemoveCloudDevSpace(cobraCmd *cobra.Command, args []string) error {
 	// Set config root
-	configExists, err := configutil.SetDevSpaceRoot()
+	configExists, err := configutil.SetDevSpaceRoot(log.GetInstance())
 	if err != nil {
 		return err
 	}

--- a/cmd/remove/sync.go
+++ b/cmd/remove/sync.go
@@ -6,6 +6,7 @@ import (
 	"github.com/devspace-cloud/devspace/cmd/flags"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/configutil"
 	"github.com/devspace-cloud/devspace/pkg/devspace/configure"
+	"github.com/devspace-cloud/devspace/pkg/util/log"
 	"github.com/spf13/cobra"
 )
 
@@ -52,7 +53,7 @@ func newSyncCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 // RunRemoveSync executes the remove sync command logic
 func (cmd *syncCmd) RunRemoveSync(cobraCmd *cobra.Command, args []string) error {
 	// Set config root
-	configExists, err := configutil.SetDevSpaceRoot()
+	configExists, err := configutil.SetDevSpaceRoot(log.GetInstance())
 	if err != nil {
 		return err
 	}

--- a/cmd/reset/vars.go
+++ b/cmd/reset/vars.go
@@ -37,7 +37,7 @@ devspace reset vars
 // RunResetVars executes the reset vars command logic
 func (cmd *varsCmd) RunResetVars(cobraCmd *cobra.Command, args []string) error {
 	// Set config root
-	configExists, err := configutil.SetDevSpaceRoot()
+	configExists, err := configutil.SetDevSpaceRoot(log.GetInstance())
 	if err != nil {
 		return err
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -26,8 +26,9 @@ func NewRunCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	cmd := &RunCmd{GlobalFlags: globalFlags}
 
 	runCmd := &cobra.Command{
-		Use:   "run",
-		Short: "Run executes a predefined command",
+		Use:                "run",
+		DisableFlagParsing: true,
+		Short:              "Run executes a predefined command",
 		Long: `
 #######################################################
 ##################### devspace run ####################

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -7,7 +7,7 @@ import (
 	"github.com/devspace-cloud/devspace/pkg/devspace/command"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/configutil"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/constants"
-	"github.com/devspace-cloud/devspace/pkg/devspace/config/versions"
+	"github.com/devspace-cloud/devspace/pkg/devspace/config/generated"
 	"github.com/devspace-cloud/devspace/pkg/util/exit"
 	"github.com/devspace-cloud/devspace/pkg/util/log"
 
@@ -70,8 +70,20 @@ func (cmd *RunCmd) RunRun(cobraCmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Load generated config
+	generatedConfig, err := generated.LoadConfig("")
+	if err != nil {
+		return err
+	}
+
 	// Parse commands
-	commands, err := versions.ParseCommands(rawMap)
+	commands, err := configutil.ParseCommands(generatedConfig, rawMap, log.GetInstance())
+	if err != nil {
+		return err
+	}
+
+	// Save variables
+	err = generated.SaveConfig(generatedConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -9,6 +9,7 @@ import (
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/constants"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/versions"
 	"github.com/devspace-cloud/devspace/pkg/util/exit"
+	"github.com/devspace-cloud/devspace/pkg/util/log"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -50,7 +51,7 @@ devspace run mycommand2 1 2 3
 // RunRun executes the functionality "devspace run"
 func (cmd *RunCmd) RunRun(cobraCmd *cobra.Command, args []string) error {
 	// Set config root
-	configExists, err := configutil.SetDevSpaceRoot()
+	configExists, err := configutil.SetDevSpaceRoot(log.Discard)
 	if err != nil {
 		return err
 	}

--- a/cmd/status/sync.go
+++ b/cmd/status/sync.go
@@ -58,7 +58,7 @@ Shows the sync status
 // RunStatusSync executes the devspace status sync commad logic
 func (cmd *syncCmd) RunStatusSync(cobraCmd *cobra.Command, args []string) error {
 	// Set config root
-	configExists, err := configutil.SetDevSpaceRoot()
+	configExists, err := configutil.SetDevSpaceRoot(log.GetInstance())
 	if err != nil {
 		return err
 	}

--- a/cmd/update/config.go
+++ b/cmd/update/config.go
@@ -40,7 +40,7 @@ Note: This does not upgrade the overwrite configs
 // RunConfig executes the functionality "devspace update config"
 func (cmd *configCmd) RunConfig(cobraCmd *cobra.Command, args []string) error {
 	// Set config root
-	configExists, err := configutil.SetDevSpaceRoot()
+	configExists, err := configutil.SetDevSpaceRoot(log.GetInstance())
 	if err != nil {
 		return err
 	}

--- a/cmd/update/dependencies.go
+++ b/cmd/update/dependencies.go
@@ -45,7 +45,7 @@ in the devspace.yaml
 // RunDependencies executes the functionality "devspace update dependencies"
 func (cmd *dependenciesCmd) RunDependencies(cobraCmd *cobra.Command, args []string) error {
 	// Set config root
-	configExists, err := configutil.SetDevSpaceRoot()
+	configExists, err := configutil.SetDevSpaceRoot(log.GetInstance())
 	if err != nil {
 		return err
 	}

--- a/cmd/use/profile.go
+++ b/cmd/use/profile.go
@@ -44,7 +44,7 @@ devspace use profile --reset
 // RunUseProfile executes the "devspace use config command" logic
 func (cmd *profileCmd) RunUseProfile(cobraCmd *cobra.Command, args []string) error {
 	// Set config root
-	configExists, err := configutil.SetDevSpaceRoot()
+	configExists, err := configutil.SetDevSpaceRoot(log.GetInstance())
 	if err != nil {
 		return err
 	}

--- a/cmd/use/space.go
+++ b/cmd/use/space.go
@@ -53,7 +53,7 @@ devspace use space my-space
 // RunUseSpace executes the functionality "devspace use space"
 func (cmd *spaceCmd) RunUseSpace(cobraCmd *cobra.Command, args []string) error {
 	// Set config root
-	configExists, err := configutil.SetDevSpaceRoot()
+	configExists, err := configutil.SetDevSpaceRoot(log.GetInstance())
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/chai2010/gettext-go v0.0.0-20170215093142-bf70f2a70fb1 // indirect
 	github.com/containerd/continuity v0.0.0-20181203112020-004b46473808 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.2 // indirect
+	github.com/davidrjenni/reftools v0.0.0-20190827201643-0605d60846fb // indirect
 	github.com/devspace-cloud/penv v0.0.1 // indirect
 	github.com/docker/cli v0.0.0-20181026145426-51668a30f262
 	github.com/docker/distribution v0.0.0-20180327202408-83389a148052
@@ -37,14 +38,17 @@ require (
 	github.com/gregjones/httpcache v0.0.0-20181110185634-c63ab54fda8f // indirect
 	github.com/hashicorp/go-version v1.0.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/haya14busa/goplay v1.0.0 // indirect
 	github.com/huandu/xstrings v1.2.0 // indirect
 	github.com/imdario/mergo v0.3.6 // indirect
 	github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf // indirect
 	github.com/jmoiron/sqlx v1.2.0 // indirect
+	github.com/josharian/impl v0.0.0-20190715203526-f0d59e96e372 // indirect
 	github.com/json-iterator/go v1.1.5 // indirect
 	github.com/juju/errors v0.0.0-20180806074554-22422dad46e1
 	github.com/juju/ratelimit v1.0.1
 	github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213
+	github.com/keegancsmith/rpc v1.1.0 // indirect
 	github.com/krishicks/yaml-patch v0.0.10
 	github.com/lib/pq v1.1.1 // indirect
 	github.com/lxn/win v0.0.0-20181015143721-a7f87360b10e // indirect
@@ -64,6 +68,7 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/rhysd/go-github-selfupdate v0.0.0-20180520142321-41c1bbb0804a
 	github.com/rjeczalik/notify v0.0.0-20181126183243-629144ba06a1
+	github.com/rogpeppe/godef v1.1.1 // indirect
 	github.com/rubenv/sql-migrate v0.0.0-20190327083759-54bad0a9b051 // indirect
 	github.com/russross/blackfriday v1.5.1 // indirect
 	github.com/sabhiram/go-gitignore v0.0.0-20180611051255-d3107576ba94
@@ -75,11 +80,14 @@ require (
 	github.com/spf13/jwalterweatherman v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.3
 	github.com/spf13/viper v1.0.2
+	github.com/stamblerre/gocode v0.0.0-20190327203809-810592086997 // indirect
 	github.com/tcnksm/go-gitconfig v0.1.2 // indirect
 	github.com/theupdateframework/notary v0.6.1 // indirect
 	github.com/toqueteos/trie v0.0.0-20150530104557-56fed4a05683 // indirect
 	github.com/ulikunitz/xz v0.5.5 // indirect
+	golang.org/x/lint v0.0.0-20190909230951-414d861bb4ac // indirect
 	golang.org/x/time v0.0.0-20181108054448-85acf8d2951c // indirect
+	golang.org/x/tools v0.0.0-20190920225731-5eefd052ad72 // indirect
 	google.golang.org/genproto v0.0.0-20181202183823-bd91e49a0898 // indirect
 	google.golang.org/grpc v1.21.0
 	gopkg.in/AlecAivazis/survey.v1 v1.8.7

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+9fans.net/go v0.0.0-20181112161441-237454027057 h1:OcHlKWkAMJEF1ndWLGxp5dnJQkYM/YImUOvsBoz6h5E=
+9fans.net/go v0.0.0-20181112161441-237454027057/go.mod h1:diCsxrliIURU9xsYtjCp5AbpQKqdhKmf0ujWDUSkfoY=
 bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690/go.mod h1:Ulb78X89vxKYgdL24HMTiXYHlyHEvruOj1ZPlqeNEZM=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0 h1:eOI3/cP2VTU6uZLDYAoic+eyzzB9YyGmJ7eIjl8rOPg=
@@ -92,6 +94,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd/go.mod h1:dv4zxwHi5C/8AeI+4gX4dCWOIvNi7I6JCSX0HvlKPgE=
+github.com/davidrjenni/reftools v0.0.0-20190827201643-0605d60846fb h1:DSSCTehMqsKHaokaWCcHEIJCqCWIrKzJaYUT/86QqSk=
+github.com/davidrjenni/reftools v0.0.0-20190827201643-0605d60846fb/go.mod h1:0qWLWApvobxwtd9/A8fS62VkRImuquIgtCv/ye+KnxA=
 github.com/devspace-cloud/penv v0.0.1 h1:0/6zHd8OShhKXYFCVN+gvazghbSVA9RlMX42JzYHRwU=
 github.com/devspace-cloud/penv v0.0.1/go.mod h1:8Yzd6mKbunJQua487BtMGHBLoVTKzEH2iX83PADg6R8=
 github.com/dgrijalva/jwt-go v0.0.0-20160705203006-01aeca54ebda/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
@@ -244,6 +248,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/hcl v0.0.0-20160711231752-d8c773c4cba1/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/haya14busa/goplay v1.0.0 h1:ED4BMrGQ3WH7H3YXrcnWMVzj1xeSepaYTkLh1DtFi/4=
+github.com/haya14busa/goplay v1.0.0/go.mod h1:TUcdOVV7TTx0Fo9CmTf16Erfju/DzXTbB70+RYb43h8=
 github.com/heketi/heketi v0.0.0-20181109135656-558b29266ce0/go.mod h1:bB9ly3RchcQqsQ9CpyaQwvva7RS5ytVoSoholZQON6o=
 github.com/heketi/rest v0.0.0-20180404230133-aa6a65207413/go.mod h1:BeS3M108VzVlmAue3lv2WcGuPAX94/KN63MUURzbYSI=
 github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6/go.mod h1:xGMAM8JLi7UkZt1i4FQeQy0R2T8GLUwQhOP5M1gBhy4=
@@ -268,6 +274,8 @@ github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht
 github.com/jmoiron/sqlx v1.2.0 h1:41Ip0zITnmWNR/vHV+S4m+VoUivnWY5E4OJfLZjCJMA=
 github.com/jmoiron/sqlx v1.2.0/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
 github.com/jonboulle/clockwork v0.0.0-20141017032234-72f9bd7c4e0c/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
+github.com/josharian/impl v0.0.0-20190715203526-f0d59e96e372 h1:zfpL1AnHJLc+2j3QphUpADoPRCnHMFCUE83V+XgYqhA=
+github.com/josharian/impl v0.0.0-20190715203526-f0d59e96e372/go.mod h1:t4Tr0tn92eq5ISef4cS5plFAMYAqZlAXtgUcKE6y8nw=
 github.com/json-iterator/go v0.0.0-20180612202835-f2b4162afba3/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v0.0.0-20180701071628-ab8a2e0c74be/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.5 h1:gL2yXlmiIo4+t+y32d4WGwOjKGYcGOuyrg46vadswDE=
@@ -285,6 +293,8 @@ github.com/kardianos/osext v0.0.0-20150410034420-8fef92e41e22/go.mod h1:1NbS8ALr
 github.com/karrick/godirwalk v1.7.5/go.mod h1:2c9FRhkDxdIbgkOnCEvnSWs71Bhugbl46shStcFDJ34=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
+github.com/keegancsmith/rpc v1.1.0 h1:bXVRk3EzbtrEegTGKxNTc+St1lR7t/Z1PAO8misBnCc=
+github.com/keegancsmith/rpc v1.1.0/go.mod h1:Xow74TKX34OPPiPCdz6x1o9c0SCxRqGxDuKGk7ZOo8s=
 github.com/kevinburke/ssh_config v0.0.0-20180830205328-81db2a75821e h1:RgQk53JHp/Cjunrr1WlsXSZpqXn+uREuHvUVcK82CV8=
 github.com/kevinburke/ssh_config v0.0.0-20180830205328-81db2a75821e/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
@@ -421,6 +431,8 @@ github.com/rhysd/go-github-selfupdate v0.0.0-20180520142321-41c1bbb0804a/go.mod 
 github.com/rjeczalik/notify v0.0.0-20181126183243-629144ba06a1 h1:FLWDC+iIP9BWgYKvWKKtOUZux35LIQNAuIzp/63RQJU=
 github.com/rjeczalik/notify v0.0.0-20181126183243-629144ba06a1/go.mod h1:aErll2f0sUX9PXZnVNyeiObbmTlk5jnMoCa4QEjJeqM=
 github.com/robfig/cron v0.0.0-20170309132418-df38d32658d8/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
+github.com/rogpeppe/godef v1.1.1 h1:NujOtt9q9vIClRTB3sCZpavac+NMRaIayzrcz1h4fSE=
+github.com/rogpeppe/godef v1.1.1/go.mod h1:oEo1eMy1VUEHUzUIX4F7IqvMJRiz9UId44mvnR8oPlQ=
 github.com/rubenv/sql-migrate v0.0.0-20190327083759-54bad0a9b051 h1:p32bQkgLiadYiOqs294BAx/7f1Aerfva8rj+rVvzR0A=
 github.com/rubenv/sql-migrate v0.0.0-20190327083759-54bad0a9b051/go.mod h1:WS0rl9eEliYI8DPnr3TOwz4439pay+qNgzJoVya/DmY=
 github.com/rubiojr/go-vhd v0.0.0-20160810183302-0bfd3b39853c/go.mod h1:DM5xW0nvfNNm2uytzsvhI3OnX8uzaRAg8UX/CnDqbto=
@@ -472,6 +484,8 @@ github.com/spf13/viper v1.0.2 h1:Ncr3ZIuJn322w2k1qmzXDnkLAdQMlJqBa9kfAH+irso=
 github.com/spf13/viper v1.0.2/go.mod h1:A8kyI5cUJhb8N+3pkfONlcEcZbueH6nhAm0Fq7SrnBM=
 github.com/src-d/gcfg v1.4.0 h1:xXbNR5AlLSA315x2UO+fTSSAXCDf+Ar38/6oyGbDKQ4=
 github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jWoI=
+github.com/stamblerre/gocode v0.0.0-20190327203809-810592086997 h1:LF81AGV63kJoxjmSgQPT8FARAMHeY46CYQ4TNoVDWHM=
+github.com/stamblerre/gocode v0.0.0-20190327203809-810592086997/go.mod h1:EM2T8YDoTCvGXbEpFHxarbpv7VE26QD1++Cb1Pbh7Gs=
 github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc/go.mod h1:ZrLn+e0ZuF3Y65PNF6dIwbJPZqfmtCXxFm9ckv0agOY=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -522,7 +536,10 @@ golang.org/x/exp v0.0.0-20190312203227-4b39c73a6495/go.mod h1:ZjyILWgesfNpC6sMxT
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20181217174547-8f45f776aaf1/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
+golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3 h1:XQyxROzUlZH+WIQwySDgnISgOivlhjIEwaQaJEJrrN0=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
+golang.org/x/lint v0.0.0-20190909230951-414d861bb4ac h1:8R1esu+8QioDxo4E4mX6bFztO+dMTM49DNAaWfO5OeY=
+golang.org/x/lint v0.0.0-20190909230951-414d861bb4ac/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -541,6 +558,8 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190502183928-7f726cade0ab h1:9RfW3ktsOZxgo9YNbBAjq1FWzc/igwEcUzZz8IXgSbk=
 golang.org/x/net v0.0.0-20190502183928-7f726cade0ab/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20190620200207-3b0461eec859 h1:R/3boaszxrf1GEUWTVDzSKVwLmSJpwZ1yqXm8j0v2QI=
+golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181203162652-d668ce993890 h1:uESlIz09WIHT2I+pasSXcpLYqYK8wHcdCetU3VuMBJE=
 golang.org/x/oauth2 v0.0.0-20181203162652-d668ce993890/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -550,6 +569,8 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 h1:YUO/7uOKsKeq9UokNS62b8FYywz3ker1l1vDZRCRefw=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180606202747-9527bec2660b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -586,10 +607,16 @@ golang.org/x/tools v0.0.0-20170824195420-5d2fd3ccab98/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20180828015842-6cd1fcedba52/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181011042414-1f849cf54d09/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/tools v0.0.0-20181130195746-895048a75ecf/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190206041539-40960b6deb8e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190312151545-0bb0c0a6e846/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
+golang.org/x/tools v0.0.0-20190328211700-ab21143f2384 h1:TFlARGu6Czu1z7q93HTxcP1P+/ZFC/IKythI5RzrnRg=
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
+golang.org/x/tools v0.0.0-20190408220357-e5b8258f4918/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
+golang.org/x/tools v0.0.0-20190920225731-5eefd052ad72 h1:bw9doJza/SFBEweII/rHQh338oozWyiFsBRHtrflcws=
+golang.org/x/tools v0.0.0-20190920225731-5eefd052ad72/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gonum.org/v1/gonum v0.0.0-20190331200053-3d26580ed485/go.mod h1:2ltnJ7xHfj0zHS40VVPYEAAMTa3ZGguvHGBSJeRWqE0=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
 gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e/go.mod h1:kS+toOQn6AQKjmKJ7gzohV1XkqsFehRA2FbsbkopSuQ=

--- a/pkg/devspace/cloud/cluster.go
+++ b/pkg/devspace/cloud/cluster.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/devspace-cloud/devspace/pkg/devspace/cloud/config"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/constants"
 	"github.com/devspace-cloud/devspace/pkg/devspace/kubectl"
 	"github.com/devspace-cloud/devspace/pkg/util/hash"
@@ -73,8 +74,13 @@ func (p *Provider) ConnectCluster(options *ConnectClusterOptions, log log.Logger
 
 	// Check what kube context to use
 	if options.KubeContext == "" {
+		allowLocalClusters := true
+		if p.Name == config.DevSpaceCloudProviderName {
+			allowLocalClusters = false
+		}
+
 		// Get kube context to use
-		client, err = kubectl.NewClientBySelect(false, true, log)
+		client, err = kubectl.NewClientBySelect(allowLocalClusters, true, log)
 		if err != nil {
 			return errors.Wrap(err, "new kubectl client")
 		}

--- a/pkg/devspace/config/configutil/get.go
+++ b/pkg/devspace/config/configutil/get.go
@@ -311,7 +311,7 @@ func validate(config *latest.Config) error {
 }
 
 // SetDevSpaceRoot checks the current directory and all parent directories for a .devspace folder with a config and sets the current working directory accordingly
-func SetDevSpaceRoot() (bool, error) {
+func SetDevSpaceRoot(log log.Logger) (bool, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return false, err

--- a/pkg/devspace/config/configutil/parse.go
+++ b/pkg/devspace/config/configutil/parse.go
@@ -70,7 +70,7 @@ func ParseConfig(generatedConfig *generated.Config, data map[interface{}]interfa
 	}
 
 	// Prepare config for variable loading
-	preparedConfig, err := versions.Prepare(data, options.Profile)
+	preparedConfig, err := versions.ParseProfile(data, options.Profile)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/devspace/config/versions/config/interface.go
+++ b/pkg/devspace/config/versions/config/interface.go
@@ -15,5 +15,5 @@ type Variables func(data map[interface{}]interface{}) (map[interface{}]interface
 // Commands strips all information from the config except commands
 type Commands func(data map[interface{}]interface{}) (map[interface{}]interface{}, error)
 
-// Prepare prepares a config for variable loading and strips unused configuration
-type Prepare func(data map[interface{}]interface{}, profile string) (map[interface{}]interface{}, error)
+// Profile loads a certain profile with the base config
+type Profile func(data map[interface{}]interface{}, profile string) (map[interface{}]interface{}, error)

--- a/pkg/devspace/config/versions/latest/load.go
+++ b/pkg/devspace/config/versions/latest/load.go
@@ -33,8 +33,8 @@ func Commands(data map[interface{}]interface{}) (map[interface{}]interface{}, er
 	}, nil
 }
 
-// Prepare prepares the given config for variable loading
-func Prepare(data map[interface{}]interface{}, profile string) (map[interface{}]interface{}, error) {
+// Profile loads a certain profile with the base config
+func Profile(data map[interface{}]interface{}, profile string) (map[interface{}]interface{}, error) {
 	loaded := map[interface{}]interface{}{}
 	err := util.Convert(data, &loaded)
 	if err != nil {

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -287,17 +287,18 @@ type OpenConfig struct {
 
 // SyncConfig defines the paths for a SyncFolder
 type SyncConfig struct {
-	ImageName            string            `yaml:"imageName,omitempty"`
-	LabelSelector        map[string]string `yaml:"labelSelector,omitempty"`
-	ContainerName        string            `yaml:"containerName,omitempty"`
-	Namespace            string            `yaml:"namespace,omitempty"`
-	LocalSubPath         string            `yaml:"localSubPath,omitempty"`
-	ContainerPath        string            `yaml:"containerPath,omitempty"`
-	ExcludePaths         []string          `yaml:"excludePaths,omitempty"`
-	DownloadExcludePaths []string          `yaml:"downloadExcludePaths,omitempty"`
-	UploadExcludePaths   []string          `yaml:"uploadExcludePaths,omitempty"`
-	WaitInitialSync      *bool             `yaml:"waitInitialSync,omitempty"`
-	BandwidthLimits      *BandwidthLimits  `yaml:"bandwidthLimits,omitempty"`
+	ImageName             string            `yaml:"imageName,omitempty"`
+	LabelSelector         map[string]string `yaml:"labelSelector,omitempty"`
+	ContainerName         string            `yaml:"containerName,omitempty"`
+	Namespace             string            `yaml:"namespace,omitempty"`
+	LocalSubPath          string            `yaml:"localSubPath,omitempty"`
+	ContainerPath         string            `yaml:"containerPath,omitempty"`
+	ExcludePaths          []string          `yaml:"excludePaths,omitempty"`
+	DownloadExcludePaths  []string          `yaml:"downloadExcludePaths,omitempty"`
+	UploadExcludePaths    []string          `yaml:"uploadExcludePaths,omitempty"`
+	DownloadOnInitialSync *bool             `yaml:"downloadOnInitialSync,omitempty"`
+	WaitInitialSync       *bool             `yaml:"waitInitialSync,omitempty"`
+	BandwidthLimits       *BandwidthLimits  `yaml:"bandwidthLimits,omitempty"`
 }
 
 // BandwidthLimits defines the struct for specifying the sync bandwidth limits

--- a/pkg/devspace/config/versions/versions.go
+++ b/pkg/devspace/config/versions/versions.go
@@ -67,7 +67,7 @@ func ParseProfile(data map[interface{}]interface{}, profile string) (map[interfa
 }
 
 // ParseCommands parses only the commands from the config
-func ParseCommands(data map[interface{}]interface{}) ([]*latest.CommandConfig, error) {
+func ParseCommands(data map[interface{}]interface{}) (*latest.Config, error) {
 	version, ok := data["version"].(string)
 	if ok == false {
 		return nil, errors.Errorf("Version is missing in devspace.yaml")
@@ -93,7 +93,7 @@ func ParseCommands(data map[interface{}]interface{}) ([]*latest.CommandConfig, e
 		return nil, errors.Wrap(err, "loading vars")
 	}
 
-	return config.Commands, nil
+	return config, nil
 }
 
 // ParseVariables parses only the variables from the config

--- a/pkg/devspace/config/versions/versions.go
+++ b/pkg/devspace/config/versions/versions.go
@@ -19,7 +19,7 @@ type loader struct {
 	New       config.New
 	Variables config.Variables
 	Commands  config.Commands
-	Prepare   config.Prepare
+	Profile   config.Profile
 }
 
 var versionLoader = map[string]*loader{
@@ -29,7 +29,7 @@ var versionLoader = map[string]*loader{
 	v1alpha4.Version: &loader{New: v1alpha4.New},
 	v1beta1.Version:  &loader{New: v1beta1.New},
 	v1beta2.Version:  &loader{New: v1beta2.New},
-	latest.Version:   &loader{New: latest.New, Variables: latest.Variables, Commands: latest.Commands, Prepare: latest.Prepare},
+	latest.Version:   &loader{New: latest.New, Variables: latest.Variables, Commands: latest.Commands, Profile: latest.Profile},
 }
 
 // ConfigOptions defines options to load the config
@@ -40,8 +40,8 @@ type ConfigOptions struct {
 	Vars []string
 }
 
-// Prepare prepares the config for variable loading
-func Prepare(data map[interface{}]interface{}, profile string) (map[interface{}]interface{}, error) {
+// ParseProfile loads the base config & a certain profile
+func ParseProfile(data map[interface{}]interface{}, profile string) (map[interface{}]interface{}, error) {
 	version, ok := data["version"].(string)
 	if ok == false {
 		return nil, errors.Errorf("Version is missing in devspace.yaml")
@@ -52,7 +52,7 @@ func Prepare(data map[interface{}]interface{}, profile string) (map[interface{}]
 		return nil, errors.Errorf("Unrecognized config version %s. Please upgrade devspace with `devspace upgrade`", version)
 	}
 
-	prepareFunc := loader.Prepare
+	prepareFunc := loader.Profile
 	if prepareFunc == nil {
 		cloned := map[interface{}]interface{}{}
 		err := util.Convert(data, &cloned)

--- a/pkg/devspace/services/sync.go
+++ b/pkg/devspace/services/sync.go
@@ -170,10 +170,16 @@ func startSync(kubeClient *kubectl.Client, pod *v1.Pod, container string, syncCo
 		containerPath = syncConfig.ContainerPath
 	}
 
+	downloadOnInitialSync := false
+	if syncConfig.DownloadOnInitialSync != nil {
+		downloadOnInitialSync = *syncConfig.DownloadOnInitialSync
+	}
+
 	options := &sync.Options{
-		Verbose:  verbose,
-		SyncDone: syncDone,
-		Log:      customLog,
+		Verbose:               verbose,
+		SyncDone:              syncDone,
+		DownloadOnInitialSync: downloadOnInitialSync,
+		Log:                   customLog,
 	}
 
 	if len(syncConfig.ExcludePaths) > 0 {

--- a/pkg/devspace/sync/sync.go
+++ b/pkg/devspace/sync/sync.go
@@ -10,9 +10,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/devspace-cloud/devspace/pkg/util/analytics/cloudanalytics"
 	"github.com/devspace-cloud/devspace/pkg/util/log"
 	"github.com/devspace-cloud/devspace/sync/remote"
-	"github.com/devspace-cloud/devspace/pkg/util/analytics/cloudanalytics"
 
 	"github.com/pkg/errors"
 	"github.com/rjeczalik/notify"
@@ -32,6 +32,8 @@ type Options struct {
 	UpstreamLimit   int64
 	DownstreamLimit int64
 	Verbose         bool
+
+	DownloadOnInitialSync bool
 
 	// These channels can be used to listen for certain sync events
 	DownstreamInitialSyncDone chan bool
@@ -284,9 +286,11 @@ func (s *Sync) initialSync() error {
 			})
 		}
 
-		err = s.downstream.applyChanges(remoteChanges)
-		if err != nil {
-			return errors.Wrap(err, "apply changes")
+		if s.Options.DownloadOnInitialSync {
+			err = s.downstream.applyChanges(remoteChanges)
+			if err != nil {
+				return errors.Wrap(err, "apply changes")
+			}
 		}
 	}
 

--- a/pkg/devspace/sync/sync_test.go
+++ b/pkg/devspace/sync/sync_test.go
@@ -249,10 +249,11 @@ func TestNormalSync(t *testing.T) {
 
 func getSyncOptions(testCases testCaseList) *Options {
 	options := &Options{
-		ExcludePaths:         []string{},
-		DownloadExcludePaths: []string{},
-		UploadExcludePaths:   []string{},
-		Verbose:              true,
+		ExcludePaths:          []string{},
+		DownloadExcludePaths:  []string{},
+		UploadExcludePaths:    []string{},
+		DownloadOnInitialSync: true,
+		Verbose:               true,
 	}
 
 	for _, testCase := range testCases {

--- a/pkg/util/vars/parse_test.go
+++ b/pkg/util/vars/parse_test.go
@@ -21,6 +21,11 @@ func TestParse(t *testing.T) {
 			replace: func(value string) (string, error) { return "test", nil },
 			output:  " test abc test ",
 		},
+		"Single Escape": &testCase{
+			input:   " test abc $${Test} ",
+			replace: func(value string) (string, error) { return "", errors.New("Shouldn't match at all") },
+			output:  " test abc ${Test} ",
+		},
 		"Multiple Replace": &testCase{
 			input:   " test ${ABC}${Test} abc $${Test}${Test} ",
 			replace: func(value string) (string, error) { return "test", nil },


### PR DESCRIPTION
Changes:
- Allow connecting private clusters in on premise providers
- Rename prepare to profile
- Disable flag parsing for `devspace run`
- Fix issue where `devspace run` would output devspace related infos
- Don't download on initial sync by default and delete non local files remotely
- New config option sync.downloadOnInitialSync 
- Allow vars in commands 