### PR TITLE
Add flag to specify provider host

### DIFF
--- a/cmd/add/provider.go
+++ b/cmd/add/provider.go
@@ -10,7 +10,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type providerCmd struct{}
+type providerCmd struct {
+	Host string
+}
 
 func newProviderCmd() *cobra.Command {
 	cmd := &providerCmd{}
@@ -32,12 +34,20 @@ devspace add provider app.devspace.cloud
 		RunE: cmd.RunAddProvider,
 	}
 
+	addProviderCmd.Flags().StringVar(&cmd.Host, "host", "", "The URL DevSpace should use for this provider")
+
 	return addProviderCmd
 }
 
 // RunAddProvider executes the "devspace add provider" functionality
 func (cmd *providerCmd) RunAddProvider(cobraCmd *cobra.Command, args []string) error {
 	providerName := args[0]
+
+	// Get host name
+	host := "https://" + providerName
+	if cmd.Host != "" {
+		host = cmd.Host
+	}
 
 	// Get provider configuration
 	providerConfig, err := config.ParseProviderConfig()
@@ -52,10 +62,10 @@ func (cmd *providerCmd) RunAddProvider(cobraCmd *cobra.Command, args []string) e
 	if provider == nil {
 		providerConfig.Providers = append(providerConfig.Providers, &latest.Provider{
 			Name: providerName,
-			Host: "https://" + providerName,
+			Host: host,
 		})
 	} else {
-		provider.Host = "https://" + providerName
+		provider.Host = host
 	}
 
 	// Ensure user is logged in

--- a/pkg/devspace/config/configutil/parse.go
+++ b/pkg/devspace/config/configutil/parse.go
@@ -304,6 +304,10 @@ func askQuestion(variable *latest.Variable, log log.Logger) (string, error) {
 			params.Question = variable.Question
 		}
 
+		if variable.Password {
+			params.IsPassword = true
+		}
+
 		if variable.Default != "" {
 			params.DefaultValue = variable.Default
 		}

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -395,6 +395,7 @@ type Variable struct {
 	Name              string          `yaml:"name"`
 	Question          string          `yaml:"question,omitempty"`
 	Options           []string        `yaml:"options,omitempty"`
+	Password          bool            `yaml:"password,omitempty"`
 	ValidationPattern string          `yaml:"validationPattern,omitempty"`
 	ValidationMessage string          `yaml:"validationMessage,omitempty"`
 	Default           string          `yaml:"default,omitempty"`


### PR DESCRIPTION
Changes:
- adds a flag --host to `devspace add provider` that allows the user to specify an arbitrary host for this provider
- add config option vars.password which hides the user input