### PR TITLE
Various changes

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -27,6 +27,8 @@ type SyncCmd struct {
 	ContainerPath string
 	LocalPath     string
 	Verbose       bool
+
+	DownloadOnInitialSync bool
 }
 
 // NewSyncCmd creates a new init command
@@ -60,6 +62,7 @@ devspace sync --container-path=/my-path
 	syncCmd.Flags().StringSliceVarP(&cmd.Exclude, "exclude", "e", []string{}, "Exclude directory from sync")
 	syncCmd.Flags().StringVar(&cmd.LocalPath, "local-path", ".", "Local path to use (Default is current directory")
 	syncCmd.Flags().StringVar(&cmd.ContainerPath, "container-path", "", "Container path to use (Default is working directory)")
+	syncCmd.Flags().BoolVar(&cmd.DownloadOnInitialSync, "download-on-initial-sync", true, "Downloads all locally non existing remote files in the beginning")
 	syncCmd.Flags().BoolVar(&cmd.Verbose, "verbose", false, "Shows every file that is synced")
 
 	return syncCmd
@@ -120,7 +123,7 @@ func (cmd *SyncCmd) Run(cobraCmd *cobra.Command, args []string) error {
 	}
 
 	// Start terminal
-	err = services.StartSyncFromCmd(config, client, params, cmd.LocalPath, cmd.ContainerPath, cmd.Exclude, cmd.Verbose, log.GetInstance())
+	err = services.StartSyncFromCmd(config, client, params, cmd.LocalPath, cmd.ContainerPath, cmd.Exclude, cmd.Verbose, cmd.DownloadOnInitialSync, log.GetInstance())
 	if err != nil {
 		return err
 	}

--- a/pkg/devspace/builder/helper/helper.go
+++ b/pkg/devspace/builder/helper/helper.go
@@ -161,7 +161,7 @@ func (b *BuildHelper) ShouldRebuild(cache *generated.CacheConfig, ignoreContextP
 		ignoreContextPathChanges = false
 		if b.Config.Dev != nil && imageCache.ImageName != "" {
 			for _, syncConfig := range b.Config.Dev.Sync {
-				if syncConfig.ImageName == imageCache.ImageName {
+				if syncConfig.ImageName == b.ImageConfigName {
 					ignoreContextPathChanges = true
 					break
 				}

--- a/pkg/devspace/builder/helper/helper.go
+++ b/pkg/devspace/builder/helper/helper.go
@@ -155,6 +155,20 @@ func (b *BuildHelper) ShouldRebuild(cache *generated.CacheConfig, ignoreContextP
 
 	// only rebuild Docker image when Dockerfile or context has changed since latest build
 	mustRebuild := imageCache.Tag == "" || imageCache.DockerfileHash != dockerfileHash || imageCache.ImageConfigHash != imageConfigHash || imageCache.EntrypointHash != entrypointHash
+
+	// Check if we really should skip context path changes, this is only the case if we find a sync config for the given image name
+	if ignoreContextPathChanges {
+		ignoreContextPathChanges = false
+		if b.Config.Dev != nil && imageCache.ImageName != "" {
+			for _, syncConfig := range b.Config.Dev.Sync {
+				if syncConfig.ImageName == imageCache.ImageName {
+					ignoreContextPathChanges = true
+					break
+				}
+			}
+		}
+	}
+
 	if ignoreContextPathChanges == false {
 		// Hash context path
 		contextDir, relDockerfile, err := build.GetContextFromLocalDir(b.ContextPath, b.DockerfilePath)

--- a/pkg/devspace/services/port_forwarding.go
+++ b/pkg/devspace/services/port_forwarding.go
@@ -12,6 +12,7 @@ import (
 	"github.com/devspace-cloud/devspace/pkg/devspace/kubectl"
 	"github.com/devspace-cloud/devspace/pkg/devspace/services/targetselector"
 	"github.com/devspace-cloud/devspace/pkg/util/log"
+	"github.com/devspace-cloud/devspace/pkg/util/port"
 	"github.com/pkg/errors"
 )
 
@@ -57,6 +58,11 @@ func StartPortForwarding(config *latest.Config, generatedConfig *generated.Confi
 					remotePort := localPort
 					if value.RemotePort != nil {
 						remotePort = strconv.Itoa(*value.RemotePort)
+					}
+
+					open, _ := port.Check(*value.LocalPort)
+					if open == false {
+						log.Warnf("Seems like port %d is already in use. Is another application using that port?", *value.LocalPort)
 					}
 
 					ports[index] = localPort + ":" + remotePort

--- a/pkg/devspace/services/sync.go
+++ b/pkg/devspace/services/sync.go
@@ -39,7 +39,7 @@ var SyncBinaryRegEx = regexp.MustCompile(`href="(\/devspace-cloud\/devspace\/rel
 const SyncHelperContainerPath = "/tmp/sync"
 
 // StartSyncFromCmd starts a new sync from command
-func StartSyncFromCmd(config *latest.Config, kubeClient *kubectl.Client, cmdParameter targetselector.CmdParameter, localPath, containerPath string, exclude []string, verbose bool, log log.Logger) error {
+func StartSyncFromCmd(config *latest.Config, kubeClient *kubectl.Client, cmdParameter targetselector.CmdParameter, localPath, containerPath string, exclude []string, verbose, downloadOnInitialSync bool, log log.Logger) error {
 	targetSelector, err := targetselector.NewTargetSelector(config, kubeClient, &targetselector.SelectorParameter{
 		CmdParameter: cmdParameter,
 	}, true, nil)
@@ -61,8 +61,9 @@ func StartSyncFromCmd(config *latest.Config, kubeClient *kubectl.Client, cmdPara
 
 	syncDone := make(chan bool)
 	syncConfig := &latest.SyncConfig{
-		LocalSubPath:  localPath,
-		ContainerPath: containerPath,
+		LocalSubPath:          localPath,
+		ContainerPath:         containerPath,
+		DownloadOnInitialSync: &downloadOnInitialSync,
 	}
 	if len(exclude) > 0 {
 		syncConfig.ExcludePaths = exclude

--- a/pkg/util/port/port.go
+++ b/pkg/util/port/port.go
@@ -1,0 +1,27 @@
+package port
+
+import (
+	"net"
+	"strconv"
+)
+
+// Check if a port is available
+func Check(port int) (status bool, err error) {
+	// Concatenate a colon and the port
+	host := ":" + strconv.Itoa(port)
+
+	// Try to create a server with the port
+	server, err := net.Listen("tcp", host)
+
+	// if it fails then the port is likely taken
+	if err != nil {
+		return false, err
+	}
+
+	// close the server
+	server.Close()
+
+	// we successfully used and closed the port
+	// so it's now available to be used again
+	return true, nil
+}


### PR DESCRIPTION
Changes:
- Add --download-on-initial-sync flag to `devspace sync` that is enabled by default (#732)
- Images will now be rebuilt during `devspace dev` if there is no sync path with the image name (#733)
- If a local port is already taken during port forwarding a warning message is shown (#739)