### PR TITLE
fix: add port forwarding on init

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -20,6 +20,7 @@ import (
 	"github.com/devspace-cloud/devspace/pkg/util/log"
 	"github.com/devspace-cloud/devspace/pkg/util/survey"
 	"github.com/mgutz/ansi"
+	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -315,52 +316,57 @@ func (cmd *InitCmd) addDevConfig() error {
 	}
 
 	// Forward ports
-	if len(config.Images) > 0 && len(config.Deployments) > 0 && config.Deployments[0].Component != nil && config.Deployments[0].Component.Service != nil && config.Deployments[0].Component.Service.Ports != nil && len(config.Deployments[0].Component.Service.Ports) > 0 {
-		servicePort := config.Deployments[0].Component.Service.Ports[0]
+	if len(config.Images) > 0 && len(config.Deployments) > 0 && config.Deployments[0].Helm != nil && config.Deployments[0].Helm.Values != nil {
+		componentValues := latest.ComponentConfig{}
 
-		if servicePort.Port != nil {
-			localPortPtr := servicePort.Port
-			var remotePortPtr *int
+		err = mapstructure.Decode(config.Deployments[0].Helm.Values, &componentValues)
+		if err == nil && componentValues.Service != nil && componentValues.Service.Ports != nil && len(componentValues.Service.Ports) > 0 {
+			servicePort := componentValues.Service.Ports[0]
 
-			if *localPortPtr < 1024 {
-				log.WriteString("\n")
-				log.Warn("Your application listens on a system port [0-1024]. Choose a forwarding-port to access your application via localhost.")
+			if servicePort.Port != nil {
+				localPortPtr := servicePort.Port
+				var remotePortPtr *int
 
-				portString, err := survey.Question(&survey.QuestionOptions{
-					Question:     "Which forwarding port [1024-49151] do you want to use to access your application?",
-					DefaultValue: strconv.Itoa(*localPortPtr + 8000),
-				}, log.GetInstance())
-				if err != nil {
-					return err
+				if *localPortPtr < 1024 {
+					log.WriteString("\n")
+					log.Warn("Your application listens on a system port [0-1024]. Choose a forwarding-port to access your application via localhost.")
+
+					portString, err := survey.Question(&survey.QuestionOptions{
+						Question:     "Which forwarding port [1024-49151] do you want to use to access your application?",
+						DefaultValue: strconv.Itoa(*localPortPtr + 8000),
+					}, log.GetInstance())
+					if err != nil {
+						return err
+					}
+
+					remotePortPtr = localPortPtr
+
+					localPort, err := strconv.Atoi(portString)
+					if err != nil {
+						return errors.Errorf("Error parsing port '%s'", portString)
+					}
+					localPortPtr = &localPort
+				}
+				portMappings := []*latest.PortMapping{}
+				portMappings = append(portMappings, &latest.PortMapping{
+					LocalPort:  localPortPtr,
+					RemotePort: remotePortPtr,
+				})
+
+				// Add dev.ports config
+				config.Dev.Ports = []*latest.PortForwardingConfig{
+					{
+						ImageName:    defaultImageName,
+						PortMappings: portMappings,
+					},
 				}
 
-				remotePortPtr = localPortPtr
-
-				localPort, err := strconv.Atoi(portString)
-				if err != nil {
-					return errors.Errorf("Error parsing port '%s'", portString)
+				// Add dev.open config
+				config.Dev.Open = []*latest.OpenConfig{
+					&latest.OpenConfig{
+						URL: "http://localhost:" + strconv.Itoa(*localPortPtr),
+					},
 				}
-				localPortPtr = &localPort
-			}
-			portMappings := []*latest.PortMapping{}
-			portMappings = append(portMappings, &latest.PortMapping{
-				LocalPort:  localPortPtr,
-				RemotePort: remotePortPtr,
-			})
-
-			// Add dev.ports config
-			config.Dev.Ports = []*latest.PortForwardingConfig{
-				{
-					ImageName:    defaultImageName,
-					PortMappings: portMappings,
-				},
-			}
-
-			// Add dev.open config
-			config.Dev.Open = []*latest.OpenConfig{
-				&latest.OpenConfig{
-					URL: "http://localhost:" + strconv.Itoa(*localPortPtr),
-				},
 			}
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -61,6 +61,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/go-ps v0.0.0-20170309133038-4fdf99ab2936 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
+	github.com/mitchellh/mapstructure v1.1.2
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/opencontainers/runc v0.1.1 // indirect

--- a/vendor/golang.org/x/net/proxy/direct.go
+++ b/vendor/golang.org/x/net/proxy/direct.go
@@ -11,8 +11,13 @@ import (
 
 type direct struct{}
 
-// Direct is a direct proxy: one that makes network connections directly.
+// Direct implements Dialer by making network connections directly using net.Dial or net.DialContext.
 var Direct = direct{}
+
+var (
+	_ Dialer        = Direct
+	_ ContextDialer = Direct
+)
 
 // Dial directly invokes net.Dial with the supplied parameters.
 func (direct) Dial(network, addr string) (net.Conn, error) {

--- a/vendor/golang.org/x/net/proxy/proxy.go
+++ b/vendor/golang.org/x/net/proxy/proxy.go
@@ -26,21 +26,30 @@ type Auth struct {
 	User, Password string
 }
 
-// FromEnvironment returns the dialer specified by the proxy related variables in
-// the environment.
+// FromEnvironment returns the dialer specified by the proxy-related
+// variables in the environment and makes underlying connections
+// directly.
 func FromEnvironment() Dialer {
+	return FromEnvironmentUsing(Direct)
+}
+
+// FromEnvironmentUsing returns the dialer specify by the proxy-related
+// variables in the environment and makes underlying connections
+// using the provided forwarding Dialer (for instance, a *net.Dialer
+// with desired configuration).
+func FromEnvironmentUsing(forward Dialer) Dialer {
 	allProxy := allProxyEnv.Get()
 	if len(allProxy) == 0 {
-		return Direct
+		return forward
 	}
 
 	proxyURL, err := url.Parse(allProxy)
 	if err != nil {
-		return Direct
+		return forward
 	}
-	proxy, err := FromURL(proxyURL, Direct)
+	proxy, err := FromURL(proxyURL, forward)
 	if err != nil {
-		return Direct
+		return forward
 	}
 
 	noProxy := noProxyEnv.Get()
@@ -48,7 +57,7 @@ func FromEnvironment() Dialer {
 		return proxy
 	}
 
-	perHost := NewPerHost(proxy, Direct)
+	perHost := NewPerHost(proxy, forward)
 	perHost.AddFromString(noProxy)
 	return perHost
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -421,7 +421,7 @@ golang.org/x/crypto/ssh
 golang.org/x/crypto/ssh/agent
 golang.org/x/crypto/ssh/knownhosts
 golang.org/x/crypto/ssh/terminal
-# golang.org/x/net v0.0.0-20190502183928-7f726cade0ab
+# golang.org/x/net v0.0.0-20190620200207-3b0461eec859
 golang.org/x/net/context
 golang.org/x/net/context/ctxhttp
 golang.org/x/net/http/httpguts
@@ -438,7 +438,7 @@ golang.org/x/oauth2/google
 golang.org/x/oauth2/internal
 golang.org/x/oauth2/jws
 golang.org/x/oauth2/jwt
-# golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4
+# golang.org/x/sync v0.0.0-20190423024810-112230192c58
 golang.org/x/sync/errgroup
 # golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a
 golang.org/x/sys/cpu


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others)  
/kind bug


**What is this pull request for? Which issues does it resolve?** (use `resolves #<issue_number>` if possible)  
Makes sure DevSpace finds the component deployment and is able to add the port forwarding configuration automatically. Due to the fact that we changed from `component` to `helm` deployment when adding the deployment during `devspace init`, the check that looks for the component was always false resulting in not adding the port forwarding config by default. This PR fixes this.