### PR TITLE
Fixed Windows Powershell Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ sudo mv devspace /usr/local/bin;
 
 ```
 md -Force "$Env:APPDATA\devspace"; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]'Tls,Tls11,Tls12';
-wget -UseBasicParsing ((Invoke-WebRequest -URI "https://github.com/devspace-cloud/devspace/releases/latest" -UseBasicParsing).Content -replace "(?ms).*`"([^`"]*devspace-windows-amd64.exe)`".*","https://github.com/`$1") -o $Env:APPDATA\devspace\devspace.exe;
+Invoke-WebRequest -UseBasicParsing ((Invoke-WebRequest -URI "https://github.com/devspace-cloud/devspace/releases/latest" -UseBasicParsing).Content -replace "(?ms).*`"([^`"]*devspace-windows-amd64.exe)`".*","https://github.com/`$1") -o $Env:APPDATA\devspace\devspace.exe;
 $env:Path += ";" + $Env:APPDATA + "\devspace";
 [Environment]::SetEnvironmentVariable("Path", $env:Path, [System.EnvironmentVariableTarget]::User);
 ```


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others)  
/kind documentation


**What is this pull request for? Which issues does it resolve?** (use `resolves #<issue_number>` if possible)  
resolves #


**Does this pull request has user-facing changes?** (e.g. config changes, new/modified commands, new/modified flags)  
Yes, just fixing the front-page README.md to a more universal Powershell syntax.

**Does this pull request add new dependencies?**  
No

**What else do we need to know?**  
I changed the Windows Powershell install command to use `Invoke-WebRequest` instead of `wget`.  wget is not an alias that Powershell has set by default in newer PSCore versions.  Tested on PSCore 6 and 7.  Older versions of Powershell for Windows, 5.1, do have `wget` aliased though to `Invoke-WebRequest`.