### PR TITLE
Hide helm deploy messages & update examples

### DIFF
--- a/examples/custom-builder/devspace.yaml
+++ b/examples/custom-builder/devspace.yaml
@@ -1,6 +1,6 @@
 # Note: This example only works in minikube, since the custom builder
 # does not push the image
-version: v1beta5
+version: v1beta4
 images:
   default:
     image: devspace

--- a/examples/dependencies/dependency1/devspace.yaml
+++ b/examples/dependencies/dependency1/devspace.yaml
@@ -1,4 +1,4 @@
-version: v1beta5
+version: v1beta4
 images:
   default:
     image: dscr.io/${DEVSPACE_USERNAME}/devspace

--- a/examples/dependencies/dependency2/devspace.yaml
+++ b/examples/dependencies/dependency2/devspace.yaml
@@ -1,4 +1,4 @@
-version: v1beta5
+version: v1beta4
 deployments:
 - name: dependency2
   helm:

--- a/examples/dependencies/devspace.yaml
+++ b/examples/dependencies/devspace.yaml
@@ -1,4 +1,4 @@
-version: v1beta5
+version: v1beta4
 deployments:
 - name: root
   helm:

--- a/examples/hooks/devspace.yaml
+++ b/examples/hooks/devspace.yaml
@@ -1,4 +1,4 @@
-version: v1beta5
+version: v1beta4
 images:
   default:
     image: dscr.io/${DEVSPACE_USERNAME}/devspace

--- a/examples/kaniko/devspace.yaml
+++ b/examples/kaniko/devspace.yaml
@@ -1,4 +1,4 @@
-version: v1beta5
+version: v1beta4
 images:
   default:
     image: devspacecloud/devspace

--- a/examples/kustomize/devspace.yaml
+++ b/examples/kustomize/devspace.yaml
@@ -1,4 +1,4 @@
-version: v1beta5
+version: v1beta4
 images:
   default:
     image: yourusername/devspace

--- a/examples/microservices/devspace.yaml
+++ b/examples/microservices/devspace.yaml
@@ -2,7 +2,7 @@
 # If you want to try this example in other
 # Clusters you have to exchange the image names
 # and enable image pushing
-version: v1beta5
+version: v1beta4
 images:
   node:
     image: node

--- a/examples/microservices/node/kube/deployment.yaml
+++ b/examples/microservices/node/kube/deployment.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: devspace
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      release: devspace-node
   template:
     metadata:
       labels:

--- a/examples/microservices/php/chart/templates/deployment.yaml
+++ b/examples/microservices/php/chart/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}
@@ -6,6 +6,9 @@ metadata:
     release: "{{ .Release.Name }}"
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      release: "{{ .Release.Name }}"
   template:
     metadata:
       annotations:

--- a/examples/minikube/chart/templates/deployment.yaml
+++ b/examples/minikube/chart/templates/deployment.yaml
@@ -1,9 +1,14 @@
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: devspace
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: {{ $.Release.Name | quote }}
+      app.kubernetes.io/name: devspace-app
+      helm.sh/chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
   template:
     metadata:
       labels:

--- a/examples/minikube/devspace.yaml
+++ b/examples/minikube/devspace.yaml
@@ -1,4 +1,4 @@
-version: v1beta5
+version: v1beta4
 images:
   default:
     image: devspace

--- a/examples/php-mysql-example/devspace.yaml
+++ b/examples/php-mysql-example/devspace.yaml
@@ -1,4 +1,4 @@
-version: v1beta5
+version: v1beta4
 images:
   default:
     image: dscr.io/${DEVSPACE_USERNAME}/devspace

--- a/examples/profiles/devspace.yaml
+++ b/examples/profiles/devspace.yaml
@@ -1,4 +1,4 @@
-version: v1beta5
+version: v1beta4
 images:
   service-image-1:
     image: dscr.io/${DEVSPACE_USERNAME}/service-1

--- a/examples/quickstart-kubectl/devspace.yaml
+++ b/examples/quickstart-kubectl/devspace.yaml
@@ -1,4 +1,4 @@
-version: v1beta5
+version: v1beta4
 images:
   default:
     image: dscr.io/yourusername/quickstart

--- a/examples/quickstart-kubectl/kube/deployment.yaml
+++ b/examples/quickstart-kubectl/kube/deployment.yaml
@@ -1,9 +1,13 @@
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: devspace
 spec:
-  replicas: 1
+  replicas: 1 
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: default
+      app.kubernetes.io/name: devspace-app
   template:
     metadata:
       labels:

--- a/examples/quickstart/devspace.yaml
+++ b/examples/quickstart/devspace.yaml
@@ -1,4 +1,4 @@
-version: v1beta5
+version: v1beta4
 images:
   default:
     image: dscr.io/${DEVSPACE_USERNAME}/devspace

--- a/examples/redeploy-instead-of-hot-reload/devspace.yaml
+++ b/examples/redeploy-instead-of-hot-reload/devspace.yaml
@@ -1,4 +1,4 @@
-version: v1beta5
+version: v1beta4
 images:
   default:
     image: yourusername/devspace

--- a/examples/redeploy-instead-of-hot-reload/kube/deployment.yaml
+++ b/examples/redeploy-instead-of-hot-reload/kube/deployment.yaml
@@ -1,9 +1,13 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: devspace
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: default
+      app.kubernetes.io/name: devspace-app
   template:
     metadata:
       labels:

--- a/examples/variables/devspace.yaml
+++ b/examples/variables/devspace.yaml
@@ -1,4 +1,4 @@
-version: v1beta5
+version: v1beta4
 deployments:
   # This will be filled with a question on `devspace deploy` or `devspace dev`, alternatevly you could also set the
   # environment variable SELECT to avoid the question and fill it automatically

--- a/pkg/devspace/deploy/kubectl/kubectl_test.go
+++ b/pkg/devspace/deploy/kubectl/kubectl_test.go
@@ -246,12 +246,15 @@ node_modules/`))
 	if err != nil {
 		return err
 	}
-	_, err = file.Write([]byte(`apiVersion: extensions/v1beta1
+	_, err = file.Write([]byte(`apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: devspace
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      release: devspace-node
   template:
     metadata:
       labels:

--- a/pkg/devspace/helm/v3/client.go
+++ b/pkg/devspace/helm/v3/client.go
@@ -61,7 +61,8 @@ func NewClient(kubeClient kubectl.Client, helmDriver string, log log.Logger) (ty
 			Releases:         store,
 			KubeClient:       kube.New(getter),
 			Log: func(msg string, params ...interface{}) {
-				log.Infof(msg, params...)
+				// We don't log helm messages
+				// log.Infof(msg, params...)
 			},
 		},
 		kubectl: kubeClient,

--- a/pkg/devspace/services/port_forwarding.go
+++ b/pkg/devspace/services/port_forwarding.go
@@ -65,7 +65,7 @@ func (serviceClient *client) StartPortForwarding() ([]*portforward.PortForwarder
 
 					ports[index] = localPort + ":" + remotePort
 					if value.BindAddress == "" {
-						addresses[index] = "127.0.0.1"
+						addresses[index] = "localhost"
 					} else {
 						addresses[index] = value.BindAddress
 					}


### PR DESCRIPTION
Changes:
- Update example deployments from extensions/v1beta1 to apps/v1
- Change default port forward address from '127.0.0.1' -> 'localhost'
- Hide helm deploy messages
