### PR TITLE
Allow --config for all commands

### DIFF
--- a/cmd/flags/flags.go
+++ b/cmd/flags/flags.go
@@ -1,8 +1,8 @@
 package flags
 
 import (
-	"github.com/devspace-cloud/devspace/pkg/devspace/config/loader"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/generated"
+	"github.com/devspace-cloud/devspace/pkg/devspace/config/loader"
 	"github.com/devspace-cloud/devspace/pkg/util/log"
 
 	"github.com/mgutz/ansi"
@@ -19,6 +19,7 @@ type GlobalFlags struct {
 	Namespace   string
 	KubeContext string
 	Profile     string
+	ConfigPath  string
 	Vars        []string
 
 	SwitchContext bool
@@ -52,6 +53,7 @@ func (gf *GlobalFlags) UseLastContext(generatedConfig *generated.Config, log log
 func (gf *GlobalFlags) ToConfigOptions() *loader.ConfigOptions {
 	return &loader.ConfigOptions{
 		Profile:     gf.Profile,
+		ConfigPath:  gf.ConfigPath,
 		KubeContext: gf.KubeContext,
 		Vars:        gf.Vars,
 	}
@@ -67,6 +69,7 @@ func SetGlobalFlags(flags *flag.FlagSet) *GlobalFlags {
 	flags.BoolVar(&globalFlags.Debug, "debug", false, "Prints the stack trace if an error occurs")
 	flags.BoolVar(&globalFlags.Silent, "silent", false, "Run in silent mode and prevents any devspace log output except panics & fatals")
 
+	flags.StringVar(&globalFlags.ConfigPath, "config", "", "The devspace config file to use")
 	flags.StringVarP(&globalFlags.Profile, "profile", "p", "", "The devspace profile to use (if there is any)")
 	flags.StringVarP(&globalFlags.Namespace, "namespace", "n", "", "The kubernetes namespace to use")
 	flags.StringVar(&globalFlags.KubeContext, "kube-context", "", "The kubernetes context to use")

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -31,8 +31,6 @@ type SyncCmd struct {
 
 	NoWatch               bool
 	DownloadOnInitialSync bool
-
-	Config string
 }
 
 // NewSyncCmd creates a new init command
@@ -72,21 +70,19 @@ devspace sync --container-path=/my-path
 	syncCmd.Flags().BoolVar(&cmd.NoWatch, "no-watch", false, "Synchronizes local and remote and then stops")
 	syncCmd.Flags().BoolVar(&cmd.Verbose, "verbose", false, "Shows every file that is synced")
 
-	syncCmd.Flags().StringVar(&cmd.Config, "config", "", "Tells DevSpace to load the sync configuration from the given devspace.yaml. Can be used together with --profile")
-
 	return syncCmd
 }
 
 // Run executes the command logic
 func (cmd *SyncCmd) Run(f factory.Factory, cobraCmd *cobra.Command, args []string) error {
 	// Switch working directory
-	if cmd.Config != "" {
-		_, err := os.Stat(cmd.Config)
+	if cmd.GlobalFlags.ConfigPath != "" {
+		_, err := os.Stat(cmd.GlobalFlags.ConfigPath)
 		if err != nil {
-			return errors.Errorf("--config is specified, but config %s cannot be loaded: %v", cmd.Config, err)
+			return errors.Errorf("--config is specified, but config %s cannot be loaded: %v", cmd.GlobalFlags.ConfigPath, err)
 		}
 
-		configPath, _ := filepath.Abs(cmd.Config)
+		configPath, _ := filepath.Abs(cmd.GlobalFlags.ConfigPath)
 		configPath = filepath.Dir(configPath)
 
 		err = os.Chdir(configPath)
@@ -161,7 +157,7 @@ func (cmd *SyncCmd) Run(f factory.Factory, cobraCmd *cobra.Command, args []strin
 		ExcludePaths:          cmd.Exclude,
 	}
 
-	if cmd.Config != "" && config.Dev != nil && len(config.Dev.Sync) > 0 {
+	if cmd.GlobalFlags.ConfigPath != "" && config.Dev != nil && len(config.Dev.Sync) > 0 {
 		// Check which sync config should be used
 		loadedSyncConfig := config.Dev.Sync[0]
 		if len(config.Dev.Sync) > 1 {

--- a/pkg/devspace/config/loader/get.go
+++ b/pkg/devspace/config/loader/get.go
@@ -1,7 +1,6 @@
 package loader
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -15,8 +14,6 @@ import (
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/constants"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/generated"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/versions/latest"
-	"github.com/devspace-cloud/devspace/pkg/devspace/deploy/deployer/helm/merge"
-	"github.com/devspace-cloud/devspace/pkg/util/yamlutil"
 )
 
 // ConfigLoader is the base interface for the main config loader
@@ -85,19 +82,18 @@ func (l *configLoader) LoadGeneratedFromPath(path string) (*generated.Config, er
 
 // Exists checks whether the yaml file for the config exists or the configs.yaml exists
 func (l *configLoader) Exists() bool {
-	return configExistsInPath(".")
+	path := constants.DefaultConfigPath
+	if l.options.ConfigPath != "" {
+		path = l.options.ConfigPath
+	}
+
+	return configExistsInPath(path)
 }
 
 // configExistsInPath checks wheter a devspace configuration exists at a certain path
 func configExistsInPath(path string) bool {
 	// Check devspace.yaml
-	_, err := os.Stat(filepath.Join(path, constants.DefaultConfigPath))
-	if err == nil {
-		return true
-	}
-
-	// Check devspace-configs.yaml
-	_, err = os.Stat(filepath.Join(path, constants.DefaultConfigsPath))
+	_, err := os.Stat(path)
 	if err == nil {
 		return true
 	}
@@ -114,6 +110,7 @@ func (l *configLoader) New() *latest.Config {
 type ConfigOptions struct {
 	Profile     string
 	KubeContext string
+	ConfigPath  string
 
 	LoadedVars map[string]string
 	Vars       []string
@@ -203,8 +200,14 @@ func (l *configLoader) loadInternal(allowProfile bool) (*latest.Config, error) {
 		l.options.Profile = ""
 	}
 
+	// What path should we use
+	path := constants.DefaultConfigPath
+	if l.options.ConfigPath != "" {
+		path = l.options.ConfigPath
+	}
+
 	// Load base config
-	config, err := l.LoadFromPath(generatedConfig, constants.DefaultConfigPath)
+	config, err := l.LoadFromPath(generatedConfig, path)
 	if err != nil {
 		return nil, err
 	}
@@ -218,131 +221,12 @@ func (l *configLoader) loadInternal(allowProfile bool) (*latest.Config, error) {
 	return config, nil
 }
 
-func validate(config *latest.Config) error {
-	if config.Dev != nil {
-		if config.Dev.Ports != nil {
-			for index, port := range config.Dev.Ports {
-				if port.ImageName == "" && port.LabelSelector == nil {
-					return errors.Errorf("Error in config: imageName and label selector are nil in port config at index %d", index)
-				}
-				if port.PortMappings == nil {
-					return errors.Errorf("Error in config: portMappings is empty in port config at index %d", index)
-				}
-			}
-		}
-
-		if config.Dev.Sync != nil {
-			for index, sync := range config.Dev.Sync {
-				if sync.ImageName == "" && sync.LabelSelector == nil {
-					return errors.Errorf("Error in config: imageName and label selector are nil in sync config at index %d", index)
-				}
-			}
-		}
-
-		if config.Dev.Interactive != nil {
-			for index, imageConf := range config.Dev.Interactive.Images {
-				if imageConf.Name == "" {
-					return errors.Errorf("Error in config: Unnamed interactive image config at index %d", index)
-				}
-			}
-		}
-	}
-
-	if config.Commands != nil {
-		for index, command := range config.Commands {
-			if command.Name == "" {
-				return errors.Errorf("commands[%d].name is required", index)
-			}
-			if command.Command == "" {
-				return errors.Errorf("commands[%d].command is required", index)
-			}
-		}
-	}
-
-	if config.Hooks != nil {
-		for index, hookConfig := range config.Hooks {
-			if hookConfig.Command == "" {
-				return errors.Errorf("hooks[%d].command is required", index)
-			}
-		}
-	}
-
-	if config.Images != nil {
-		for imageConfigName, imageConf := range config.Images {
-			if imageConfigName == "" {
-				return errors.Errorf("images keys cannot be an empty string")
-			}
-			if imageConf == nil {
-				return errors.Errorf("images.%s is empty and should at least contain an image name", imageConfigName)
-			}
-			if imageConf.Image == "" {
-				return errors.Errorf("images.%s.image is required", imageConfigName)
-			}
-			if imageConf.Build != nil && imageConf.Build.Custom != nil && imageConf.Build.Custom.Command == "" {
-				return errors.Errorf("images.%s.build.custom.command is required", imageConfigName)
-			}
-			if imageConf.Image == "" {
-				return fmt.Errorf("images.%s.image is required", imageConfigName)
-			}
-		}
-	}
-
-	if config.Deployments != nil {
-		for index, deployConfig := range config.Deployments {
-			if deployConfig.Name == "" {
-				return errors.Errorf("deployments[%d].name is required", index)
-			}
-			if deployConfig.Helm == nil && deployConfig.Kubectl == nil {
-				return errors.Errorf("Please specify either helm or kubectl as deployment type in deployment %s", deployConfig.Name)
-			}
-			if deployConfig.Helm != nil && (deployConfig.Helm.Chart == nil || deployConfig.Helm.Chart.Name == "") && (deployConfig.Helm.ComponentChart == nil || *deployConfig.Helm.ComponentChart == false) {
-				return errors.Errorf("deployments[%d].helm.chart and deployments[%d].helm.chart.name or deployments[%d].helm.componentChart is required", index, index, index)
-			}
-			if deployConfig.Kubectl != nil && deployConfig.Kubectl.Manifests == nil {
-				return errors.Errorf("deployments[%d].kubectl.manifests is required", index)
-			}
-			if deployConfig.Helm != nil && deployConfig.Helm.ComponentChart != nil && *deployConfig.Helm.ComponentChart == true {
-				// Load override values from path
-				overwriteValues := map[interface{}]interface{}{}
-				if deployConfig.Helm.ValuesFiles != nil {
-					for _, overridePath := range deployConfig.Helm.ValuesFiles {
-						overwriteValuesPath, err := filepath.Abs(overridePath)
-						if err != nil {
-							return errors.Errorf("deployments[%d].helm.valuesFiles: Error retrieving absolute path from %s: %v", index, overridePath, err)
-						}
-
-						overwriteValuesFromPath := map[interface{}]interface{}{}
-						err = yamlutil.ReadYamlFromFile(overwriteValuesPath, overwriteValuesFromPath)
-						if err == nil {
-							merge.Values(overwriteValues).MergeInto(overwriteValuesFromPath)
-						}
-					}
-				}
-
-				// Load override values from data and merge them
-				if deployConfig.Helm.Values != nil {
-					merge.Values(overwriteValues).MergeInto(deployConfig.Helm.Values)
-				}
-
-				bytes, err := yaml.Marshal(overwriteValues)
-				if err != nil {
-					return errors.Errorf("deployments[%d].helm: Error marshaling overwrite values: %v", index, err)
-				}
-
-				componentValues := &latest.ComponentConfig{}
-				err = yaml.UnmarshalStrict(bytes, componentValues)
-				if err != nil {
-					return errors.Errorf("deployments[%d].helm.componentChart: component values are incorrect: %v", index, err)
-				}
-			}
-		}
-	}
-
-	return nil
-}
-
 // SetDevSpaceRoot checks the current directory and all parent directories for a .devspace folder with a config and sets the current working directory accordingly
 func (l *configLoader) SetDevSpaceRoot() (bool, error) {
+	if l.options.ConfigPath != "" {
+		return configExistsInPath(l.options.ConfigPath), nil
+	}
+
 	cwd, err := os.Getwd()
 	if err != nil {
 		return false, err
@@ -357,7 +241,7 @@ func (l *configLoader) SetDevSpaceRoot() (bool, error) {
 	lastLength := 0
 	for len(cwd) != lastLength {
 		if cwd != homedir {
-			configExists := configExistsInPath(cwd)
+			configExists := configExistsInPath(filepath.Join(cwd, constants.DefaultConfigPath))
 			if configExists {
 				// Change working directory
 				err = os.Chdir(cwd)

--- a/pkg/devspace/config/loader/validate.go
+++ b/pkg/devspace/config/loader/validate.go
@@ -1,0 +1,136 @@
+package loader
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	yaml "gopkg.in/yaml.v2"
+
+	"github.com/devspace-cloud/devspace/pkg/devspace/config/versions/latest"
+	"github.com/devspace-cloud/devspace/pkg/devspace/deploy/deployer/helm/merge"
+	"github.com/devspace-cloud/devspace/pkg/util/yamlutil"
+)
+
+func validate(config *latest.Config) error {
+	if config.Dev != nil {
+		if config.Dev.Ports != nil {
+			for index, port := range config.Dev.Ports {
+				if port.ImageName == "" && port.LabelSelector == nil {
+					return errors.Errorf("Error in config: imageName and label selector are nil in port config at index %d", index)
+				}
+				if port.PortMappings == nil {
+					return errors.Errorf("Error in config: portMappings is empty in port config at index %d", index)
+				}
+			}
+		}
+
+		// if config.Dev.Sync != nil {
+		// 	for index, sync := range config.Dev.Sync {
+		// 		if sync.ImageName == "" && sync.LabelSelector == nil {
+		// 			return errors.Errorf("Error in config: imageName and label selector are nil in sync config at index %d", index)
+		// 		}
+		// 	}
+		// }
+
+		if config.Dev.Interactive != nil {
+			for index, imageConf := range config.Dev.Interactive.Images {
+				if imageConf.Name == "" {
+					return errors.Errorf("Error in config: Unnamed interactive image config at index %d", index)
+				}
+			}
+		}
+	}
+
+	if config.Commands != nil {
+		for index, command := range config.Commands {
+			if command.Name == "" {
+				return errors.Errorf("commands[%d].name is required", index)
+			}
+			if command.Command == "" {
+				return errors.Errorf("commands[%d].command is required", index)
+			}
+		}
+	}
+
+	if config.Hooks != nil {
+		for index, hookConfig := range config.Hooks {
+			if hookConfig.Command == "" {
+				return errors.Errorf("hooks[%d].command is required", index)
+			}
+		}
+	}
+
+	if config.Images != nil {
+		for imageConfigName, imageConf := range config.Images {
+			if imageConfigName == "" {
+				return errors.Errorf("images keys cannot be an empty string")
+			}
+			if imageConf == nil {
+				return errors.Errorf("images.%s is empty and should at least contain an image name", imageConfigName)
+			}
+			if imageConf.Image == "" {
+				return errors.Errorf("images.%s.image is required", imageConfigName)
+			}
+			if imageConf.Build != nil && imageConf.Build.Custom != nil && imageConf.Build.Custom.Command == "" {
+				return errors.Errorf("images.%s.build.custom.command is required", imageConfigName)
+			}
+			if imageConf.Image == "" {
+				return fmt.Errorf("images.%s.image is required", imageConfigName)
+			}
+		}
+	}
+
+	if config.Deployments != nil {
+		for index, deployConfig := range config.Deployments {
+			if deployConfig.Name == "" {
+				return errors.Errorf("deployments[%d].name is required", index)
+			}
+			if deployConfig.Helm == nil && deployConfig.Kubectl == nil {
+				return errors.Errorf("Please specify either helm or kubectl as deployment type in deployment %s", deployConfig.Name)
+			}
+			if deployConfig.Helm != nil && (deployConfig.Helm.Chart == nil || deployConfig.Helm.Chart.Name == "") && (deployConfig.Helm.ComponentChart == nil || *deployConfig.Helm.ComponentChart == false) {
+				return errors.Errorf("deployments[%d].helm.chart and deployments[%d].helm.chart.name or deployments[%d].helm.componentChart is required", index, index, index)
+			}
+			if deployConfig.Kubectl != nil && deployConfig.Kubectl.Manifests == nil {
+				return errors.Errorf("deployments[%d].kubectl.manifests is required", index)
+			}
+			if deployConfig.Helm != nil && deployConfig.Helm.ComponentChart != nil && *deployConfig.Helm.ComponentChart == true {
+				// Load override values from path
+				overwriteValues := map[interface{}]interface{}{}
+				if deployConfig.Helm.ValuesFiles != nil {
+					for _, overridePath := range deployConfig.Helm.ValuesFiles {
+						overwriteValuesPath, err := filepath.Abs(overridePath)
+						if err != nil {
+							return errors.Errorf("deployments[%d].helm.valuesFiles: Error retrieving absolute path from %s: %v", index, overridePath, err)
+						}
+
+						overwriteValuesFromPath := map[interface{}]interface{}{}
+						err = yamlutil.ReadYamlFromFile(overwriteValuesPath, overwriteValuesFromPath)
+						if err == nil {
+							merge.Values(overwriteValues).MergeInto(overwriteValuesFromPath)
+						}
+					}
+				}
+
+				// Load override values from data and merge them
+				if deployConfig.Helm.Values != nil {
+					merge.Values(overwriteValues).MergeInto(deployConfig.Helm.Values)
+				}
+
+				bytes, err := yaml.Marshal(overwriteValues)
+				if err != nil {
+					return errors.Errorf("deployments[%d].helm: Error marshaling overwrite values: %v", index, err)
+				}
+
+				componentValues := &latest.ComponentConfig{}
+				err = yaml.UnmarshalStrict(bytes, componentValues)
+				if err != nil {
+					return errors.Errorf("deployments[%d].helm.componentChart: component values are incorrect: %v", index, err)
+				}
+			}
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Changes:
- Allows `--config` as flag for all commands to specify where the devspace.yaml is