### PR TITLE
--config fixes

### DIFF
--- a/cmd/dev.go
+++ b/cmd/dev.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"sync"
@@ -130,6 +131,7 @@ func (cmd *DevCmd) Run(f factory.Factory, cobraCmd *cobra.Command, args []string
 		return err
 	}
 	if !configExists {
+		fmt.Println(cmd.configLoader.ConfigPath())
 		return errors.New(message.ConfigNotFound)
 	}
 

--- a/cmd/dev.go
+++ b/cmd/dev.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 	"strings"
 	"sync"
@@ -131,7 +130,6 @@ func (cmd *DevCmd) Run(f factory.Factory, cobraCmd *cobra.Command, args []string
 		return err
 	}
 	if !configExists {
-		fmt.Println(cmd.configLoader.ConfigPath())
 		return errors.New(message.ConfigNotFound)
 	}
 

--- a/cmd/list/commands.go
+++ b/cmd/list/commands.go
@@ -2,7 +2,6 @@ package list
 
 import (
 	"github.com/devspace-cloud/devspace/cmd/flags"
-	"github.com/devspace-cloud/devspace/pkg/devspace/config/constants"
 	"github.com/devspace-cloud/devspace/pkg/util/factory"
 	"github.com/devspace-cloud/devspace/pkg/util/log"
 	"github.com/devspace-cloud/devspace/pkg/util/message"
@@ -55,7 +54,7 @@ func (cmd *commandsCmd) RunListProfiles(f factory.Factory, cobraCmd *cobra.Comma
 	}
 
 	// Load commands
-	bytes, err := ioutil.ReadFile(constants.DefaultConfigPath)
+	bytes, err := ioutil.ReadFile(configLoader.ConfigPath())
 	if err != nil {
 		return err
 	}

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 
 	"github.com/devspace-cloud/devspace/cmd/flags"
-	"github.com/devspace-cloud/devspace/pkg/devspace/config/constants"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/generated"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/loader"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/versions"
@@ -94,10 +93,7 @@ func printExtraInfo(configOptions *loader.ConfigOptions, configLoader loader.Con
 	if err != nil {
 		return err
 	}
-	path := constants.DefaultConfigPath
-	if configOptions.ConfigPath != "" {
-		path = configOptions.ConfigPath
-	}
+	path := configLoader.ConfigPath()
 	absPath := filepath.Join(pwd, path)
 
 	log.WriteString("\n-------------------\n\nVars:\n")

--- a/cmd/set/var.go
+++ b/cmd/set/var.go
@@ -4,8 +4,8 @@ import (
 	"io/ioutil"
 	"strings"
 
-	"github.com/devspace-cloud/devspace/pkg/devspace/config/constants"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/generated"
+	"github.com/devspace-cloud/devspace/pkg/devspace/config/loader"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/versions"
 	"github.com/devspace-cloud/devspace/pkg/util/factory"
 	"github.com/devspace-cloud/devspace/pkg/util/log"
@@ -61,7 +61,7 @@ func (cmd *varCmd) RunSetVar(f factory.Factory, cobraCmd *cobra.Command, args []
 		return err
 	}
 
-	allowedVars, err := getPossibleVars(generatedConfig, log)
+	allowedVars, err := getPossibleVars(generatedConfig, configLoader, log)
 	if err != nil {
 		return errors.Wrap(err, "get possible vars")
 	}
@@ -97,9 +97,9 @@ func (cmd *varCmd) RunSetVar(f factory.Factory, cobraCmd *cobra.Command, args []
 	return nil
 }
 
-func getPossibleVars(generatedConfig *generated.Config, log log.Logger) (map[string]bool, error) {
+func getPossibleVars(generatedConfig *generated.Config, configLoader loader.ConfigLoader, log log.Logger) (map[string]bool, error) {
 	// Load variables
-	bytes, err := ioutil.ReadFile(constants.DefaultConfigPath)
+	bytes, err := ioutil.ReadFile(configLoader.ConfigPath())
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/devspace-cloud/devspace/cmd/flags"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/generated"
@@ -85,14 +84,6 @@ func (cmd *SyncCmd) Run(f factory.Factory, cobraCmd *cobra.Command, args []strin
 		_, err := os.Stat(cmd.GlobalFlags.ConfigPath)
 		if err != nil {
 			return errors.Errorf("--config is specified, but config %s cannot be loaded: %v", cmd.GlobalFlags.ConfigPath, err)
-		}
-
-		configPath, _ := filepath.Abs(cmd.GlobalFlags.ConfigPath)
-		configPath = filepath.Dir(configPath)
-
-		err = os.Chdir(configPath)
-		if err != nil {
-			return errors.Wrap(err, "change working directory")
 		}
 	}
 

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/devspace-cloud/devspace/cmd/flags"
-	"github.com/devspace-cloud/devspace/pkg/devspace/config/constants"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/generated"
 	latest "github.com/devspace-cloud/devspace/pkg/devspace/config/versions/latest"
 	"github.com/devspace-cloud/devspace/pkg/devspace/server"
@@ -157,11 +156,7 @@ func (cmd *UICmd) RunUI(f factory.Factory, cobraCmd *cobra.Command, args []strin
 
 	configOptions := cmd.ToConfigOptions()
 
-	path := constants.DefaultConfigPath
-	if configOptions.ConfigPath != "" {
-		path = configOptions.ConfigPath
-	}
-
+	path := configLoader.ConfigPath()
 	values := [][]string{}
 
 	err = fillCurrentVars(configOptions, configLoader, path, &values, cmd.log)

--- a/pkg/devspace/config/loader/get.go
+++ b/pkg/devspace/config/loader/get.go
@@ -84,10 +84,7 @@ func (l *configLoader) SaveGenerated(generatedConfig *generated.Config) error {
 
 // Exists checks whether the yaml file for the config exists or the configs.yaml exists
 func (l *configLoader) Exists() bool {
-	path := constants.DefaultConfigPath
-	if l.options.ConfigPath != "" {
-		path = l.options.ConfigPath
-	}
+	path := l.ConfigPath()
 
 	return configExistsInPath(path)
 }

--- a/pkg/devspace/config/loader/get.go
+++ b/pkg/devspace/config/loader/get.go
@@ -27,6 +27,7 @@ type ConfigLoader interface {
 	LoadRaw(path string) (map[interface{}]interface{}, error)
 	LoadWithoutProfile() (*latest.Config, error)
 
+	ConfigPath() string
 	GetProfiles() ([]string, error)
 	ResolveVar(varName string, generatedConfig *generated.Config, cmdVars map[string]string) (string, error)
 	ParseCommands(generatedConfig *generated.Config, data map[interface{}]interface{}) ([]*latest.CommandConfig, error)
@@ -159,6 +160,15 @@ func (l *configLoader) LoadRaw(configPath string) (map[interface{}]interface{}, 
 	return rawMap, nil
 }
 
+func (l *configLoader) ConfigPath() string {
+	path := constants.DefaultConfigPath
+	if l.options.ConfigPath != "" {
+		path = l.options.ConfigPath
+	}
+
+	return path
+}
+
 // LoadPath loads the config from a given base path
 func (l *configLoader) LoadFromPath(generatedConfig *generated.Config, configPath string) (*latest.Config, error) {
 	// Check devspace.yaml
@@ -202,10 +212,7 @@ func (l *configLoader) loadInternal(allowProfile bool) (*latest.Config, error) {
 	}
 
 	// What path should we use
-	path := constants.DefaultConfigPath
-	if l.options.ConfigPath != "" {
-		path = l.options.ConfigPath
-	}
+	path := l.ConfigPath()
 
 	// Load base config
 	config, err := l.LoadFromPath(generatedConfig, path)

--- a/pkg/devspace/config/loader/parse.go
+++ b/pkg/devspace/config/loader/parse.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/devspace-cloud/devspace/pkg/devspace/config/constants"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/generated"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/versions"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/versions/latest"
@@ -22,11 +21,7 @@ func varMatchFn(path, key, value string) bool {
 
 // GetProfiles retrieves all available profiles
 func (l *configLoader) GetProfiles() ([]string, error) {
-	path := constants.DefaultConfigPath
-	if l.options.ConfigPath != "" {
-		path = l.options.ConfigPath
-	}
-
+	path := l.ConfigPath()
 	bytes, err := ioutil.ReadFile(path)
 	if err != nil {
 		return nil, err

--- a/pkg/devspace/config/loader/save.go
+++ b/pkg/devspace/config/loader/save.go
@@ -4,7 +4,6 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/devspace-cloud/devspace/pkg/devspace/config/constants"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/versions/util"
 	"github.com/devspace-cloud/devspace/pkg/devspace/deploy/deployer/kubectl/walk"
 	"github.com/pkg/errors"
@@ -39,10 +38,11 @@ func (l *configLoader) RestoreVars(config *latest.Config) (*latest.Config, error
 	}
 
 	// Check if config exists
-	_, err = os.Stat(constants.DefaultConfigPath)
+	path := l.ConfigPath()
+	_, err = os.Stat(path)
 	if err == nil {
 		// Shallow merge with config from file to add vars, configs etc.
-		bytes, err := ioutil.ReadFile(constants.DefaultConfigPath)
+		bytes, err := ioutil.ReadFile(path)
 		if err != nil {
 			return nil, err
 		}
@@ -97,11 +97,11 @@ func (l *configLoader) Save(config *latest.Config) error {
 		return errors.Wrap(err, "restore vars")
 	}
 
-	return saveConfig(clonedConfig)
+	return saveConfig(l.ConfigPath(), clonedConfig)
 }
 
 // saveConfig saves the config to file
-func saveConfig(config *latest.Config) error {
+func saveConfig(path string, config *latest.Config) error {
 	// Convert to string
 	configYaml, err := yaml.Marshal(config)
 	if err != nil {
@@ -109,7 +109,7 @@ func saveConfig(config *latest.Config) error {
 	}
 
 	// Path to save the configuration to
-	err = ioutil.WriteFile(constants.DefaultConfigPath, configYaml, os.ModePerm)
+	err = ioutil.WriteFile(path, configYaml, os.ModePerm)
 	if err != nil {
 		return err
 	}

--- a/pkg/devspace/config/loader/testing/fake.go
+++ b/pkg/devspace/config/loader/testing/fake.go
@@ -45,6 +45,10 @@ func (f *FakeConfigLoader) Load() (*latest.Config, error) {
 	return f.Config, nil
 }
 
+func (f *FakeConfigLoader) ConfigPath() string {
+	return ""
+}
+
 func (f *FakeConfigLoader) ResolveVar(varName string, generatedConfig *generated.Config, cmdVars map[string]string) (string, error) {
 	return "", nil
 }

--- a/pkg/devspace/deploy/deployer/kubectl/kubectl_test.go
+++ b/pkg/devspace/deploy/deployer/kubectl/kubectl_test.go
@@ -369,7 +369,7 @@ func TestDeploy(t *testing.T) {
 			expectedDeployed: true,
 			expectedPaths:    []string{"myPath", "myPath"},
 			expectedArgs: [][]string{
-				[]string{"create", "--context", "myContext", "--namespace", "myNamespace", "--dry-run", "--save-config", "--output", "yaml", "--validate=false", "--filename", "/"},
+				[]string{"create", "--context", "myContext", "--namespace", "myNamespace", "--dry-run", "--save-config", "--output", "yaml", "--validate=false", "--filename", "."},
 				[]string{"--context", "myContext", "--namespace", "myNamespace", "apply", "--force", "-f", "-", "someFlag"},
 			},
 		},

--- a/pkg/devspace/deploy/deployer/kubectl/kubectl_test.go
+++ b/pkg/devspace/deploy/deployer/kubectl/kubectl_test.go
@@ -364,7 +364,7 @@ func TestDeploy(t *testing.T) {
 			cmdPath:          "myPath",
 			context:          "myContext",
 			namespace:        "myNamespace",
-			manifests:        []string{"/"},
+			manifests:        []string{"."},
 			kubectlFlags:     []string{"someFlag"},
 			expectedDeployed: true,
 			expectedPaths:    []string{"myPath", "myPath"},

--- a/pkg/devspace/server/server.go
+++ b/pkg/devspace/server/server.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/devspace-cloud/devspace/pkg/devspace/config/constants"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/generated"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/loader"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/versions/latest"
@@ -161,7 +160,7 @@ func newHandler(configLoader loader.ConfigLoader, config *latest.Config, generat
 
 	// Load raw config
 	if config != nil {
-		configPath := filepath.Join(cwd, constants.DefaultConfigPath)
+		configPath := configLoader.ConfigPath()
 		handler.rawConfig, err = configLoader.LoadRaw(configPath)
 		if err != nil {
 			return nil, errors.Wrap(err, "load raw config")


### PR DESCRIPTION
Changes:
- Fixes an issue where --config would not be recognized by the ui server (#935)
- Fixes an issue where --config was not correctly applied for subfolders in `devspace sync` (#937)
- Fixes a long running unit test in the package pkg/devspace/deploy/deployer/kubectl