### PR TITLE
Push image in devspace build with local kubernetes

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -98,14 +98,8 @@ func (cmd *BuildCmd) Run(f factory.Factory, cobraCmd *cobra.Command, args []stri
 		}
 	}
 
-	// Create kubectl client and switch context if specified
-	client, err := f.NewKubeClientFromContext(cmd.KubeContext, cmd.Namespace, cmd.SwitchContext)
-	if err != nil {
-		return errors.Errorf("Unable to create new kubectl client: %v", err)
-	}
-
 	// Create Dependencymanager
-	manager, err := f.NewDependencyManager(config, generatedConfig, client, cmd.AllowCyclicDependencies, configOptions, log)
+	manager, err := f.NewDependencyManager(config, generatedConfig, nil, cmd.AllowCyclicDependencies, configOptions, log)
 	if err != nil {
 		return errors.Wrap(err, "new manager")
 	}
@@ -122,7 +116,7 @@ func (cmd *BuildCmd) Run(f factory.Factory, cobraCmd *cobra.Command, args []stri
 	}
 
 	// Build images if necessary
-	builtImages, err := f.NewBuildController(config, generatedConfig.GetActive(), client).Build(&build.Options{
+	builtImages, err := f.NewBuildController(config, generatedConfig.GetActive(), nil).Build(&build.Options{
 		SkipPush:     cmd.SkipPush,
 		IsDev:        true,
 		ForceRebuild: cmd.ForceBuild,


### PR DESCRIPTION
## Changes
- Fixes an issue where `devspace build` would not push images if the current kubernetes context was `minikube` or `docker-desktop`