### PR TITLE
Add `devspace set encryptionkey`

### DIFF
--- a/cmd/set/encryptionkey.go
+++ b/cmd/set/encryptionkey.go
@@ -1,0 +1,79 @@
+package set
+
+import (
+	"github.com/devspace-cloud/devspace/pkg/util/factory"
+	"github.com/devspace-cloud/devspace/pkg/util/hash"
+	"github.com/pkg/errors"
+
+	"github.com/spf13/cobra"
+)
+
+type encryptionkeyCmd struct {
+	Cluster string
+}
+
+func newEncryptionKeyCmd(f factory.Factory) *cobra.Command {
+	cmd := &encryptionkeyCmd{}
+
+	encryptionkeyCmd := &cobra.Command{
+		Use:   "encryptionkey",
+		Short: "Sets the encryption",
+		Long: `
+#######################################################
+############## devspace set encryptionkey #############
+#######################################################
+Sets an encryption key for a given cluster
+
+Examples:
+devspace set encryptionkey mykey --cluster mycluster 
+devspace set encryptionkey --cluster mycluster --reset
+#######################################################
+	`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cobraCmd *cobra.Command, args []string) error {
+			return cmd.RunSetEncryptionKey(f, cobraCmd, args)
+		}}
+
+	encryptionkeyCmd.Flags().StringVar(&cmd.Cluster, "cluster", "", "The cluster to apply this key for")
+
+	return encryptionkeyCmd
+}
+
+// RunSetEncryptionKey executes the set encryptionkey command logic
+func (cmd *encryptionkeyCmd) RunSetEncryptionKey(f factory.Factory, cobraCmd *cobra.Command, args []string) error {
+	if cmd.Cluster == "" {
+		return errors.Errorf("--cluster has to be specified. You can view the available clusters with `devspace list clusters`")
+	}
+
+	// Get provider configuration
+	provider, err := f.GetProvider("", f.GetLog())
+	if err != nil {
+		return err
+	}
+
+	cluster, err := provider.Client().GetClusterByName(cmd.Cluster)
+	if err != nil {
+		return errors.Wrap(err, "get cluster")
+	}
+
+	hashedKey, err := hash.Password(args[0])
+	if err != nil {
+		return errors.Wrap(err, "hash key")
+	}
+
+	valid, err := provider.Client().VerifyKey(cluster.ClusterID, hashedKey)
+	if err != nil {
+		return errors.Wrap(err, "is key valid")
+	} else if !valid {
+		return errors.Errorf("Provided key is not valid for cluster %s", args[0])
+	}
+
+	provider.GetConfig().ClusterKey[cluster.ClusterID] = hashedKey
+	err = provider.Save()
+	if err != nil {
+		return errors.Wrap(err, "save provider")
+	}
+
+	f.GetLog().Infof("Successfully set encryption key for cluster %s", args[0])
+	return nil
+}

--- a/cmd/set/set.go
+++ b/cmd/set/set.go
@@ -20,6 +20,7 @@ func NewSetCmd(f factory.Factory) *cobra.Command {
 
 	setCmd.AddCommand(newAnalyticsCmd(f))
 	setCmd.AddCommand(newVarCmd(f))
+	setCmd.AddCommand(newEncryptionKeyCmd(f))
 
 	return setCmd
 }

--- a/pkg/devspace/cloud/cluster.go
+++ b/pkg/devspace/cloud/cluster.go
@@ -256,8 +256,10 @@ func (p *provider) defaultClusterSpaceDomain(client kubectl.Client, useHostNetwo
 			}
 
 			// Check loadbalancer for an ip
+			found := false
 			for _, service := range services.Items {
 				if service.Spec.Type == v1.ServiceTypeLoadBalancer {
+					found = true
 					for _, ingress := range service.Status.LoadBalancer.Ingress {
 						if ingress.Hostname != "" {
 							break Outer
@@ -267,6 +269,9 @@ func (p *provider) defaultClusterSpaceDomain(client kubectl.Client, useHostNetwo
 						}
 					}
 				}
+			}
+			if !found {
+				return nil
 			}
 
 			time.Sleep(5 * time.Second)


### PR DESCRIPTION
## Changes
- Adds a new command `devspace set encryptionkey` to set the cluster encryptionkey in pipelines (#991)
- Allows deployment of devspace-cloud into another namespace