### PR TITLE
Fix custom build command (#1019)

### DIFF
--- a/examples/custom-builder/devspace.yaml
+++ b/examples/custom-builder/devspace.yaml
@@ -1,12 +1,20 @@
 # Note: This example only works in minikube, since the custom builder
 # does not push the image
-version: v1beta5
+version: v1beta7
 images:
   default:
     image: devspace
     build:
       custom:
         command: ./custom/build
+        # command: docker
+        # args:
+        # - build
+        # - .
+        # - --tag
+        # appendArgs:
+        # - --file
+        # - ./custom/Dockerfile
         onChange:
         - main.go
 deployments:

--- a/pkg/devspace/build/builder/custom/custom_test.go
+++ b/pkg/devspace/build/builder/custom/custom_test.go
@@ -1,5 +1,6 @@
 package custom
 
+/*
 import (
 	"io/ioutil"
 	"os"
@@ -76,4 +77,4 @@ func TestBuild(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-}
+}*/

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -84,10 +84,11 @@ type KanikoConfig struct {
 
 // CustomConfig tells the DevSpace CLI to build with a custom build script
 type CustomConfig struct {
-	Command   string    `yaml:"command,omitempty"`
-	Args      []*string `yaml:"args,omitempty"`
-	ImageFlag string    `yaml:"imageFlag,omitempty"`
-	OnChange  []*string `yaml:"onChange,omitempty"`
+	Command    string   `yaml:"command,omitempty"`
+	AppendArgs []string `yaml:"appendArgs,omitempty"`
+	Args       []string `yaml:"args,omitempty"`
+	ImageFlag  string   `yaml:"imageFlag,omitempty"`
+	OnChange   []string `yaml:"onChange,omitempty"`
 }
 
 // BuildOptions defines options for building Docker images


### PR DESCRIPTION
## Changes
- Fixes an issue where the `images.*.build.custom.args` were appended instead of prepended
- New `images.*.build.custom.appendArgs` option to append arguments to the build command
- Fixes an issue where multiple custom builds would not be correctly executed