### PR TITLE
Add reference to JSON Patch RFC for Patching Semantics

### DIFF
--- a/docs/versioned_docs/version-4.7/configuration/profiles/patches.mdx
+++ b/docs/versioned_docs/version-4.7/configuration/profiles/patches.mdx
@@ -6,7 +6,7 @@ sidebar_label: patches
 import FragmentInfoPrintConfig from '../../fragments/tip-print-config.mdx';
 import FragmentProfileParent from '../../fragments/profile-parent.mdx';
 
-Patches are a way to perform minor overrides to the configuration without having to create a separate config file.
+Patches are a way to perform minor overrides to the configuration without having to create a separate config file. Patch functionality follows JSON Patch([RFC](https://tools.ietf.org/html/rfc6902)) semantics, as implemented by the [yaml-patch](https://github.com/krishicks/yaml-patch) library.
 
 ## Example
 Patches are ideal for reflecting changes between different environments, e.g. dev, staging and production.


### PR DESCRIPTION
It took me a long time to understand what was possible with patches. I found a comment on PR #994 that referenced the yaml-patch library[1] devspace is using, and a link to the JSON Patch RFC, so I'm suggesting adding that information here to help future developers.

[1] https://github.com/krishicks/yaml-patch

**What issue type does this pull request address?** (keep at least one, remove the others)  
/kind documentation

**What is this pull request for? Which issues does it resolve?** Documentation update to help developers understand patching when creating profiles.

**Does this pull request has user-facing changes?** (e.g. config changes, new/modified commands, new/modified flags) Just documentation.

**Does this pull request add new dependencies?**   No.