### PR TITLE
Fix kubectl issue & ui client caching

### DIFF
--- a/pkg/devspace/build/build.go
+++ b/pkg/devspace/build/build.go
@@ -69,8 +69,17 @@ func (c *controller) Build(options *Options, log logpkg.Logger) (map[string]stri
 	}
 
 	// Build not in parallel when we only have one image to build
-	if options.Sequential == false && len(c.config.Images) <= 1 {
-		options.Sequential = true
+	if options.Sequential == false {
+		// check if all images are disabled besides one
+		imagesToBuild := 0
+		for _, image := range c.config.Images {
+			if image.Build == nil || image.Build.Disabled == nil || *image.Build.Disabled == false {
+				imagesToBuild++
+			}
+		}
+		if len(c.config.Images) <= 1 || imagesToBuild <= 1 {
+			options.Sequential = true
+		}
 	}
 
 	// Execute before images build hook

--- a/pkg/devspace/deploy/deployer/kubectl/builder.go
+++ b/pkg/devspace/deploy/deployer/kubectl/builder.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"os/exec"
 	"regexp"
+	"strings"
 )
 
 // Builder is the manifest builder interface
@@ -94,10 +95,27 @@ func (k *kubectlBuilder) Build(manifest string, cmd RunCommand) ([]*unstructured
 		return nil, err
 	}
 
-	return stringToUnstructuredArray(string(output))
+	return stringToUnstructuredArray(prepareResources(string(output)))
 }
 
 var diffSeparator = regexp.MustCompile(`\n---`)
+var oldDiffSeparator = regexp.MustCompile(`\napiVersion`)
+
+func prepareResources(out string) string {
+	retStr := ""
+	parts := diffSeparator.Split(out, -1)
+	for _, part := range parts {
+		oldParts := oldDiffSeparator.Split(part, -1)
+		if len(oldParts) > 1 {
+			retStr += strings.Join(oldParts, "\n---\napiVersion")
+		} else {
+			retStr += part
+		}
+	}
+
+
+	return retStr
+}
 
 // stringToUnstructuredArray splits a YAML file into unstructured objects. Returns a list of all unstructured objects
 func stringToUnstructuredArray(out string) ([]*unstructured.Unstructured, error) {

--- a/pkg/devspace/server/enter.go
+++ b/pkg/devspace/server/enter.go
@@ -7,8 +7,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/devspace-cloud/devspace/pkg/devspace/kubectl"
-	"github.com/devspace-cloud/devspace/pkg/util/kubeconfig"
 	"github.com/gorilla/websocket"
 )
 
@@ -39,7 +37,7 @@ func (h *handler) enter(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Create kubectl client
-	client, err := kubectl.NewClientFromContext(kubeContext, kubeNamespace, false, kubeconfig.NewLoader())
+	client, err := h.getClientFromCache(kubeContext, kubeNamespace)
 	if err != nil {
 		h.log.Errorf("Error in %s: %v", r.URL.String(), err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/pkg/devspace/server/logs.go
+++ b/pkg/devspace/server/logs.go
@@ -67,7 +67,7 @@ func (h *handler) logsMultiple(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Create kubectl client
-	client, err := kubectl.NewClientFromContext(kubeContext, kubeNamespace, false, kubeconfig.NewLoader())
+	client, err := h.getClientFromCache(kubeContext, kubeNamespace)
 	if err != nil {
 		h.log.Errorf("Error in %s: %v", r.URL.String(), err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/pkg/devspace/server/port_forward.go
+++ b/pkg/devspace/server/port_forward.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/devspace-cloud/devspace/pkg/devspace/kubectl"
-	"github.com/devspace-cloud/devspace/pkg/util/kubeconfig"
 	"github.com/devspace-cloud/devspace/pkg/util/port"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -51,7 +49,7 @@ func (h *handler) forward(w http.ResponseWriter, r *http.Request) {
 	defer h.portsMutex.Unlock()
 
 	// Create kubectl client
-	client, err := kubectl.NewClientFromContext(kubeContext, kubeNamespace, false, kubeconfig.NewLoader())
+	client, err := h.getClientFromCache(kubeContext, kubeNamespace)
 	if err != nil {
 		h.log.Errorf("Error in %s: %v", r.URL.String(), err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/pkg/devspace/server/server.go
+++ b/pkg/devspace/server/server.go
@@ -106,8 +106,8 @@ type handler struct {
 	log              log.Logger
 	mux              *http.ServeMux
 
-	clientCache map[string]kubectl.Client
-	clientCacheMutext sync.Mutex
+	clientCache      map[string]kubectl.Client
+	clientCacheMutex sync.Mutex
 
 	ports      map[string]*forward
 	portsMutex sync.Mutex
@@ -154,9 +154,7 @@ func newHandler(configLoader loader.ConfigLoader, config *latest.Config, generat
 		log:              log,
 		generatedConfig:  generatedConfig,
 		ports:            make(map[string]*forward),
-
-		clientCacheMutext: sync.Mutex{},
-		clientCache: make(map[string]kubectl.Client),
+		clientCache:      make(map[string]kubectl.Client),
 	}
 
 	analytics, err := analytics.GetAnalytics()
@@ -342,8 +340,8 @@ func (h *handler) request(w http.ResponseWriter, r *http.Request) {
 func (h *handler) getClientFromCache(kubeContext, kubeNamespace string) (kubectl.Client, error) {
 	key := kubeNamespace + ":" + kubeContext
 
-	h.clientCacheMutext.Lock()
-	defer h.clientCacheMutext.Unlock()
+	h.clientCacheMutex.Lock()
+	defer h.clientCacheMutex.Unlock()
 
 	var err error
 	client, ok := h.clientCache[key]

--- a/pkg/devspace/server/server.go
+++ b/pkg/devspace/server/server.go
@@ -106,6 +106,9 @@ type handler struct {
 	log              log.Logger
 	mux              *http.ServeMux
 
+	clientCache map[string]kubectl.Client
+	clientCacheMutext sync.Mutex
+
 	ports      map[string]*forward
 	portsMutex sync.Mutex
 }
@@ -151,6 +154,9 @@ func newHandler(configLoader loader.ConfigLoader, config *latest.Config, generat
 		log:              log,
 		generatedConfig:  generatedConfig,
 		ports:            make(map[string]*forward),
+
+		clientCacheMutext: sync.Mutex{},
+		clientCache: make(map[string]kubectl.Client),
 	}
 
 	analytics, err := analytics.GetAnalytics()
@@ -311,12 +317,11 @@ func (h *handler) request(w http.ResponseWriter, r *http.Request) {
 		options.LabelSelector = labelSelector[0]
 	}
 
-	// Create kubectl client
-	client, err := kubectl.NewClientFromContext(kubeContext, kubeNamespace, false, kubeconfig.NewLoader())
+	// check client cache
+	client, err := h.getClientFromCache(kubeContext, kubeNamespace)
 	if err != nil {
 		h.log.Errorf("Error in %s: %v", r.URL.String(), err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
 	}
 
 	// Do the request
@@ -332,4 +337,24 @@ func (h *handler) request(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.Write([]byte(out))
+}
+
+func (h *handler) getClientFromCache(kubeContext, kubeNamespace string) (kubectl.Client, error) {
+	key := kubeNamespace + ":" + kubeContext
+
+	h.clientCacheMutext.Lock()
+	defer h.clientCacheMutext.Unlock()
+
+	var err error
+	client, ok := h.clientCache[key]
+	if !ok {
+		client, err = kubectl.NewClientFromContext(kubeContext, kubeNamespace, false, kubeconfig.NewLoader())
+		if err != nil {
+			return nil, err
+		}
+
+		h.clientCache[key] = client
+	}
+
+	return client, nil
 }


### PR DESCRIPTION
# Changes
- Fixes an issue where kubectl deployments with older versions of kubectl would only deploy a single yaml 
- devspace now caches kubectl clients to avoid the `constructing many client instances from the same exec auth config` warning
- shows docker image building output if all images are disabled besides one
