### PR TITLE
fix cache flag for kaniko

### DIFF
--- a/pkg/devspace/build/builder/kaniko/build_pod.go
+++ b/pkg/devspace/build/builder/kaniko/build_pod.go
@@ -89,7 +89,7 @@ func (b *Builder) getBuildPod(buildID string, options *types.ImageBuildOptions, 
 	kanikoArgs = append(kanikoArgs, kanikoOptions.Args...)
 
 	// Cache
-	if !options.NoCache {
+	if kanikoOptions.Cache == nil || *kanikoOptions.Cache == true {
 		ref, err := reference.ParseNormalizedNamed(b.FullImageName)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
# Changes
- fixes an issue where `images.build.kaniko.cache` had no effect