### PR TITLE
Custom kaniko image & mounts

### DIFF
--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -1,10 +1,13 @@
 package cmd
 
 import (
+	"fmt"
 	"github.com/devspace-cloud/devspace/cmd/flags"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/generated"
+	"github.com/devspace-cloud/devspace/pkg/devspace/config/loader"
 	"github.com/devspace-cloud/devspace/pkg/devspace/services/targetselector"
 	"github.com/devspace-cloud/devspace/pkg/util/factory"
+	"github.com/devspace-cloud/devspace/pkg/util/message"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -14,6 +17,7 @@ type LogsCmd struct {
 	*flags.GlobalFlags
 
 	LabelSelector string
+	Image         string
 	Container     string
 	Pod           string
 	Pick          bool
@@ -50,6 +54,7 @@ devspace logs --namespace=mynamespace
 	logsCmd.Flags().StringVarP(&cmd.Container, "container", "c", "", "Container name within pod where to execute command")
 	logsCmd.Flags().StringVar(&cmd.Pod, "pod", "", "Pod to print the logs of")
 	logsCmd.Flags().StringVarP(&cmd.LabelSelector, "label-selector", "l", "", "Comma separated key=value selector list (e.g. release=test)")
+	logsCmd.Flags().StringVar(&cmd.Image, "image", "", "Image is the config name of an image to select in the devspace config (e.g. 'default'), it is NOT a docker image like myuser/myimage")
 	logsCmd.Flags().BoolVar(&cmd.Pick, "pick", false, "Select a pod")
 	logsCmd.Flags().BoolVarP(&cmd.Follow, "follow", "f", false, "Attach to logs afterwards")
 	logsCmd.Flags().IntVar(&cmd.LastAmountOfLines, "lines", 200, "Max amount of lines to print from the last log")
@@ -114,12 +119,44 @@ func (cmd *LogsCmd) RunLogs(f factory.Factory, cobraCmd *cobra.Command, args []s
 		CmdParameter: params,
 	}
 
+	// get imageselector if specified
+	imageSelector, err := getImageSelector(configLoader, cmd.Image)
+	if err != nil {
+		return err
+	}
+
 	// Start terminal
 	servicesClient := f.NewServicesClient(nil, generatedConfig, client, selectorParameter, log)
-	err = servicesClient.StartLogs(cmd.Follow, int64(cmd.LastAmountOfLines))
+	err = servicesClient.StartLogs(imageSelector, cmd.Follow, int64(cmd.LastAmountOfLines))
 	if err != nil {
 		return err
 	}
 
 	return nil
+}
+
+func getImageSelector(configLoader loader.ConfigLoader, image string) ([]string, error) {
+	var imageSelector []string
+	if image != "" {
+		if !configLoader.Exists() {
+			return nil, errors.New(message.ConfigNotFound)
+		}
+
+		config, err := configLoader.Load()
+		if err != nil {
+			return nil, err
+		}
+
+		generatedConfig, err := configLoader.Generated()
+		if err != nil {
+			return nil, err
+		}
+
+		imageSelector = targetselector.ImageSelectorFromConfig(image, config, generatedConfig)
+		if len(imageSelector) == 0 {
+			return nil, fmt.Errorf("couldn't find an image with name %s in devspace config", image)
+		}
+	}
+
+	return imageSelector, nil
 }

--- a/examples/kaniko/devspace.yaml
+++ b/examples/kaniko/devspace.yaml
@@ -1,10 +1,26 @@
-version: v1beta7
+version: v1beta8
 images:
   default:
-    image: myuser/myimage
+    image: devspacecloud/myimage
     build:
       kaniko:
         cache: true
+        # custom kaniko image
+        # image: mykaniko/kaniko:latest
+        # additional mounts for the kaniko pod
+        # additionalMounts:
+        #  - configMap:
+        #      name: test
+        #      items:
+        #        - key: key
+        #          path: config.json
+        #    mountPath: /test/test
+        #  - secret:
+        #      name: test2
+        #      items:
+        #        - key: key
+        #          path: config.json
+        #    mountPath: /test/test
 deployments:
 - name: devspace-default
   helm:

--- a/examples/kaniko/devspace.yaml
+++ b/examples/kaniko/devspace.yaml
@@ -1,7 +1,7 @@
 version: v1beta8
 images:
   default:
-    image: devspacecloud/myimage
+    image: myuser/myimage
     build:
       kaniko:
         cache: true

--- a/pkg/devspace/build/builder/kaniko/build_pod.go
+++ b/pkg/devspace/build/builder/kaniko/build_pod.go
@@ -1,6 +1,7 @@
 package kaniko
 
 import (
+	"github.com/docker/distribution/reference"
 	"path/filepath"
 
 	"github.com/docker/docker/api/types"
@@ -10,7 +11,6 @@ import (
 	"fmt"
 
 	"github.com/devspace-cloud/devspace/pkg/devspace/registry"
-	"github.com/docker/distribution/reference"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -85,9 +85,6 @@ func (b *Builder) getBuildPod(buildID string, options *types.ImageBuildOptions, 
 		kanikoArgs = append(kanikoArgs, "--build-arg", newKanikoArg)
 	}
 
-	// Extra flags
-	kanikoArgs = append(kanikoArgs, kanikoOptions.Args...)
-
 	// Cache
 	if kanikoOptions.Cache == nil || *kanikoOptions.Cache == true {
 		ref, err := reference.ParseNormalizedNamed(b.FullImageName)
@@ -97,6 +94,9 @@ func (b *Builder) getBuildPod(buildID string, options *types.ImageBuildOptions, 
 
 		kanikoArgs = append(kanikoArgs, "--cache=true", "--cache-repo="+ref.Name())
 	}
+
+	// Extra flags
+	kanikoArgs = append(kanikoArgs, kanikoOptions.Args...)
 
 	// Get available resources
 	availableResources, err := b.getAvailableResources()

--- a/pkg/devspace/build/builder/kaniko/kaniko.go
+++ b/pkg/devspace/build/builder/kaniko/kaniko.go
@@ -273,7 +273,7 @@ func (b *Builder) BuildImage(contextPath, dockerfilePath string, entrypoint []st
 		servicesClient := services.NewClient(b.helper.Config, nil, b.helper.KubeClient, &targetselector.SelectorParameter{
 			CmdParameter: targetselector.CmdParameter{PodName: buildPod.Name, ContainerName: buildPod.Spec.Containers[0].Name, Namespace: buildPod.Namespace},
 		}, log)
-		err = servicesClient.StartLogsWithWriter(true, 100, stdoutLogger)
+		err = servicesClient.StartLogsWithWriter(nil, true, 100, stdoutLogger)
 		if err != nil {
 			return errors.Errorf("Error during printling build logs: %v", err)
 		}

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -73,13 +73,122 @@ type DockerConfig struct {
 
 // KanikoConfig tells the DevSpace CLI to build with Docker on Minikube or on localhost
 type KanikoConfig struct {
-	Cache        *bool         `yaml:"cache,omitempty"`
-	SnapshotMode string        `yaml:"snapshotMode,omitempty"`
-	Args         []string      `yaml:"args,omitempty"`
-	Namespace    string        `yaml:"namespace,omitempty"`
-	Insecure     *bool         `yaml:"insecure,omitempty"`
-	PullSecret   string        `yaml:"pullSecret,omitempty"`
-	Options      *BuildOptions `yaml:"options,omitempty"`
+	// if a cache repository should be used. defaults to true
+	Cache *bool `yaml:"cache,omitempty"`
+
+	// the snapshot mode kaniko should use. defaults to time
+	SnapshotMode string `yaml:"snapshotMode,omitempty"`
+
+	// the image name of the kaniko pod to use
+	Image string `yaml:"image,omitempty"`
+
+	// additional arguments that should be passed to kaniko
+	Args []string `yaml:"args,omitempty"`
+
+	// the namespace where the kaniko pod should be run
+	Namespace string `yaml:"namespace,omitempty"`
+
+	// if true pushing to insecure registries is allowed
+	Insecure *bool `yaml:"insecure,omitempty"`
+
+	// the pull secret to mount by default
+	PullSecret string `yaml:"pullSecret,omitempty"`
+
+	// additional mounts that will be added to the build pod
+	AdditionalMounts []KanikoAdditionalMount `yaml:"additionalMounts,omitempty"`
+
+	// other build options that will be passed to the kaniko pod
+	Options *BuildOptions `yaml:"options,omitempty"`
+}
+
+// KanikoAdditionalMount tells devspace how the additional mount of the kaniko pod should look like
+type KanikoAdditionalMount struct {
+	// The secret that should be mounted
+	Secret *KanikoAdditionalMountSecret `yaml:"secret,omitempty"`
+
+	// The configMap that should be mounted
+	ConfigMap *KanikoAdditionalMountConfigMap `yaml:"configMap,omitempty"`
+
+	// Mounted read-only if true, read-write otherwise (false or unspecified).
+	// Defaults to false.
+	// +optional
+	ReadOnly bool `yaml:"readOnly,omitempty"`
+
+	// Path within the container at which the volume should be mounted.  Must
+	// not contain ':'.
+	MountPath string `yaml:"mountPath,omitempty"`
+
+	// Path within the volume from which the container's volume should be mounted.
+	// Defaults to "" (volume's root).
+	// +optional
+	SubPath string `yaml:"subPath,omitempty"`
+}
+
+type KanikoAdditionalMountConfigMap struct {
+	// Name of the configmap
+	// +optional
+	Name string `yaml:"name,omitempty"`
+
+	// If unspecified, each key-value pair in the Data field of the referenced
+	// ConfigMap will be projected into the volume as a file whose name is the
+	// key and content is the value. If specified, the listed keys will be
+	// projected into the specified paths, and unlisted keys will not be
+	// present. If a key is specified which is not present in the ConfigMap,
+	// the volume setup will error unless it is marked optional. Paths must be
+	// relative and may not contain the '..' path or start with '..'.
+	// +optional
+	Items []KanikoAdditionalMountKeyToPath `yaml:"items,omitempty"`
+
+	// Optional: mode bits to use on created files by default. Must be a
+	// value between 0 and 0777. Defaults to 0644.
+	// Directories within the path are not affected by this setting.
+	// This might be in conflict with other options that affect the file
+	// mode, like fsGroup, and the result can be other mode bits set.
+	// +optional
+	DefaultMode *int32 `yaml:"defaultMode,omitempty"`
+}
+
+type KanikoAdditionalMountSecret struct {
+	// Name of the secret in the pod's namespace to use.
+	// More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+	// +optional
+	Name string `yaml:"name"`
+
+	// If unspecified, each key-value pair in the Data field of the referenced
+	// Secret will be projected into the volume as a file whose name is the
+	// key and content is the value. If specified, the listed keys will be
+	// projected into the specified paths, and unlisted keys will not be
+	// present. If a key is specified which is not present in the Secret,
+	// the volume setup will error unless it is marked optional. Paths must be
+	// relative and may not contain the '..' path or start with '..'.
+	// +optional
+	Items []KanikoAdditionalMountKeyToPath `yaml:"items,omitempty"`
+
+	// Optional: mode bits to use on created files by default. Must be a
+	// value between 0 and 0777. Defaults to 0644.
+	// Directories within the path are not affected by this setting.
+	// This might be in conflict with other options that affect the file
+	// mode, like fsGroup, and the result can be other mode bits set.
+	// +optional
+	DefaultMode *int32 `yaml:"defaultMode,omitempty"`
+}
+
+type KanikoAdditionalMountKeyToPath struct {
+	// The key to project.
+	Key string `yaml:"key"`
+
+	// The relative path of the file to map the key to.
+	// May not be an absolute path.
+	// May not contain the path element '..'.
+	// May not start with the string '..'.
+	Path string `yaml:"path"`
+
+	// Optional: mode bits to use on this file, must be a value between 0
+	// and 0777. If not specified, the volume defaultMode will be used.
+	// This might be in conflict with other options that affect the file
+	// mode, like fsGroup, and the result can be other mode bits set.
+	// +optional
+	Mode *int32 `yaml:"mode,omitempty"`
 }
 
 // CustomConfig tells the DevSpace CLI to build with a custom build script

--- a/pkg/devspace/services/client.go
+++ b/pkg/devspace/services/client.go
@@ -14,8 +14,8 @@ import (
 type Client interface {
 	StartAttach(imageSelector []string, interrupt chan error) error
 
-	StartLogs(follow bool, tail int64) error
-	StartLogsWithWriter(follow bool, tail int64, writer io.Writer) error
+	StartLogs(imageSelector []string, follow bool, tail int64) error
+	StartLogsWithWriter(imageSelector []string, follow bool, tail int64, writer io.Writer) error
 
 	StartPortForwarding(interrupt chan error) error
 

--- a/pkg/devspace/services/logs.go
+++ b/pkg/devspace/services/logs.go
@@ -10,13 +10,13 @@ import (
 )
 
 // StartLogs print the logs and then attaches to the container
-func (serviceClient *client) StartLogs(follow bool, tail int64) error {
-	return serviceClient.StartLogsWithWriter(follow, tail, os.Stdout)
+func (serviceClient *client) StartLogs(imageSelector []string, follow bool, tail int64) error {
+	return serviceClient.StartLogsWithWriter(imageSelector, follow, tail, os.Stdout)
 }
 
 // StartLogsWithWriter prints the logs and then attaches to the container with the given stdout and stderr
-func (serviceClient *client) StartLogsWithWriter(follow bool, tail int64, writer io.Writer) error {
-	targetSelector, err := targetselector.NewTargetSelector(serviceClient.config, serviceClient.client, serviceClient.selectorParameter, true, nil)
+func (serviceClient *client) StartLogsWithWriter(imageSelector []string, follow bool, tail int64, writer io.Writer) error {
+	targetSelector, err := targetselector.NewTargetSelector(serviceClient.config, serviceClient.client, serviceClient.selectorParameter, true, imageSelector)
 	if err != nil {
 		return err
 	}

--- a/pkg/devspace/services/sync.go
+++ b/pkg/devspace/services/sync.go
@@ -425,7 +425,6 @@ func (serviceClient *client) downloadSyncHelper(filepath, syncBinaryFolder, vers
 	// Check if file exists
 	_, err := os.Stat(filepath)
 	if err == nil {
-
 		// make sure the sha is correct, but skip for latest because that is development
 		if version == "latest" {
 			return nil
@@ -435,17 +434,21 @@ func (serviceClient *client) downloadSyncHelper(filepath, syncBinaryFolder, vers
 		url := fmt.Sprintf("https://github.com/devspace-cloud/devspace/releases/download/%s/sync.sha256", version)
 		resp, err := http.Get(url)
 		if err != nil {
-			return errors.Wrap(err, "get url")
+			serviceClient.log.Warnf("Couldn't retrieve sync sha256: %v", err)
+			return nil
 		}
 
 		shaHash, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			return errors.Wrap(err, "read sync sha body")
+			serviceClient.log.Warnf("Couldn't read sync sha256 request: %v", err)
+			return nil
 		}
 
+		// hash the local binary
 		fileHash, err := hash.File(filepath)
 		if err != nil {
-			return errors.Wrap(err, "hash local sync binary")
+			serviceClient.log.Warnf("Couldn't hash local sync binary: %v", err)
+			return nil
 		}
 
 		// the file is correct we skip downloading

--- a/pkg/util/hash/hash.go
+++ b/pkg/util/hash/hash.go
@@ -23,6 +23,23 @@ func Password(password string) (string, error) {
 	return hex.EncodeToString(sha256Bytes[:]), nil
 }
 
+// File creates the hash value of a file
+func File(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	hash := sha256.New()
+	_, err = io.Copy(hash, file)
+	if err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
 // Directory creates the hash value of a directory
 func Directory(path string) (string, error) {
 	hash := sha256.New()


### PR DESCRIPTION
# Changes
- New option `images.*.build.kaniko.image` that makes it possible to specify a custom kaniko build image
- New option `images.*.build.kaniko.additionalMounts` that allows to specify additional custom mounts for the kaniko pods
- New `--image` flag for `devspace enter`, `devspace logs & `devspace attach` that selects a pod by the provided devspace config image name
- Fixed an issue that could lead to devspace uploading a corrupt sync binary into a container which resulted in the error `command terminated exit code 139`