### PR TITLE
build: prefer docker over kaniko if both are set

### DIFF
--- a/pkg/devspace/build/create_builder.go
+++ b/pkg/devspace/build/create_builder.go
@@ -86,6 +86,18 @@ func (c *controller) createBuilder(imageConfigName string, imageConf *latest.Ima
 }
 
 func convertDockerConfigToKanikoConfig(dockerConfig *latest.ImageConfig) *latest.ImageConfig {
+	kanikoBuildOptions := &latest.KanikoConfig{
+		Cache: ptr.Bool(true),
+	}
+
+	if dockerConfig.Build != nil && dockerConfig.Build.Kaniko != nil {
+		kanikoBuildOptions = dockerConfig.Build.Kaniko
+	} else {
+		if dockerConfig.Build != nil && dockerConfig.Build.Docker != nil && dockerConfig.Build.Docker.Options != nil {
+			kanikoBuildOptions.Options = dockerConfig.Build.Docker.Options
+		}
+	}
+
 	kanikoConfig := &latest.ImageConfig{
 		Image:            dockerConfig.Image,
 		Tags:             dockerConfig.Tags,
@@ -95,14 +107,8 @@ func convertDockerConfigToKanikoConfig(dockerConfig *latest.ImageConfig) *latest
 		Cmd:              dockerConfig.Cmd,
 		CreatePullSecret: dockerConfig.CreatePullSecret,
 		Build: &latest.BuildConfig{
-			Kaniko: &latest.KanikoConfig{
-				Cache: ptr.Bool(true),
-			},
+			Kaniko: kanikoBuildOptions,
 		},
-	}
-
-	if dockerConfig.Build != nil && dockerConfig.Build.Docker != nil && dockerConfig.Build.Docker.Options != nil {
-		kanikoConfig.Build.Kaniko.Options = dockerConfig.Build.Docker.Options
 	}
 
 	return kanikoConfig

--- a/pkg/devspace/build/create_builder.go
+++ b/pkg/devspace/build/create_builder.go
@@ -23,7 +23,7 @@ func (c *controller) createBuilder(imageConfigName string, imageConf *latest.Ima
 
 	if imageConf.Build != nil && imageConf.Build.Custom != nil {
 		builder = custom.NewBuilder(imageConfigName, imageConf, imageTag)
-	} else if imageConf.Build != nil && imageConf.Build.Kaniko != nil {
+	} else if imageConf.Build != nil && imageConf.Build.Docker == nil && imageConf.Build.Kaniko != nil {
 		dockerClient, err := dockerclient.NewClient(log)
 		if err != nil {
 			return nil, errors.Errorf("Error creating docker client: %v", err)

--- a/pkg/devspace/build/create_builder.go
+++ b/pkg/devspace/build/create_builder.go
@@ -92,10 +92,8 @@ func convertDockerConfigToKanikoConfig(dockerConfig *latest.ImageConfig) *latest
 
 	if dockerConfig.Build != nil && dockerConfig.Build.Kaniko != nil {
 		kanikoBuildOptions = dockerConfig.Build.Kaniko
-	} else {
-		if dockerConfig.Build != nil && dockerConfig.Build.Docker != nil && dockerConfig.Build.Docker.Options != nil {
-			kanikoBuildOptions.Options = dockerConfig.Build.Docker.Options
-		}
+	} else if dockerConfig.Build != nil && dockerConfig.Build.Docker != nil && dockerConfig.Build.Docker.Options != nil {
+		kanikoBuildOptions.Options = dockerConfig.Build.Docker.Options
 	}
 
 	kanikoConfig := &latest.ImageConfig{

--- a/pkg/devspace/sync/sync_test.go
+++ b/pkg/devspace/sync/sync_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package sync
 
 import (

--- a/pkg/devspace/sync/util_test.go
+++ b/pkg/devspace/sync/util_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package sync
 
 import (

--- a/sync/server/downstream_test.go
+++ b/sync/server/downstream_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package server
 
 import (

--- a/sync/server/upstream_test.go
+++ b/sync/server/upstream_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package server
 
 import (


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others)  
/kind enhancement


**What is this pull request for? Which issues does it resolve?** (use `resolves #<issue_number>` if possible)  
Because kaniko is fallback to docker, it should be 2nd priority if both are defined. Currently it is 1st priority which does not sounds like a fallback. Inverting this is more understandable and also more expected from a user perspective.

This PR also has the huge advantage that we can now configure docker and still be able to configure the fallback as well. So far, a common use case is that users need `snapshotMode: full` because they have `RUN chmod ..` lines in their Dockerfiles. Without this settings, the kaniko fallback is effectively useless because the resulting image will not be executable due to permission errors. With this PR, users can just configure all kaniko options and they will also be used during the fallback.


**Does this pull request has user-facing changes?** (e.g. config changes, new/modified commands, new/modified flags)  
Users with both, kaniko and docker configured would see a difference but because kaniko always supersedes docker currently, no one should have both configured right now because the docker options would never be used. So, although the preference will change from kaniko to docker, no one will notice this change.

**Does this pull request add new dependencies?**  
No

**What else do we need to know?**  
