### PR TITLE
enhancements for init command and restart helper

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -405,8 +405,11 @@ func (cmd *InitCmd) addDevConfig(config *latest.Config) error {
 			}
 
 			syncConfig := append(config.Dev.Sync, &latest.SyncConfig{
-				ImageName:    defaultImageName,
-				ExcludePaths: excludePaths,
+				ImageName:          defaultImageName,
+				UploadExcludePaths: excludePaths,
+				OnUpload: &latest.SyncOnUpload{
+					RestartContainer: true,
+				},
 			})
 
 			config.Dev.Sync = syncConfig

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -314,6 +314,7 @@ func openURL(url string, kubectlClient kubectl.Client, analyzeNamespace string, 
 		resp, _ := http.Get(url)
 		if resp != nil && resp.StatusCode != http.StatusBadGateway && resp.StatusCode != http.StatusServiceUnavailable {
 			log.StopWait()
+			time.Sleep(time.Second * 1)
 			open.Start(url)
 			log.Donef("Successfully opened %s", url)
 			return nil

--- a/go.sum
+++ b/go.sum
@@ -741,11 +741,13 @@ github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:v
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+github.com/onsi/ginkgo v1.10.1 h1:q/mM8GF/n0shIN8SaAZ0V+jnLPzen6WIVZdiwrRlMlo=
 github.com/onsi/ginkgo v1.10.1/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v0.0.0-20190113212917-5533ce8a0da3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/onsi/gomega v1.7.0 h1:XPnZz8VVBHjVsy1vzJmRwIcSwiUO+JFfrv/xGiigmME=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=

--- a/go.sum
+++ b/go.sum
@@ -1195,6 +1195,7 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+y
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 h1:/atklqdjdhuosWIl6AIbOeHJjicWYPqR9bpxqxYG2pA=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gonum.org/v1/gonum v0.0.0-20190331200053-3d26580ed485/go.mod h1:2ltnJ7xHfj0zHS40VVPYEAAMTa3ZGguvHGBSJeRWqE0=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=

--- a/pkg/devspace/build/builder/docker/docker.go
+++ b/pkg/devspace/build/builder/docker/docker.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"github.com/docker/cli/cli/streams"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/docker/cli/cli/streams"
 
 	"github.com/devspace-cloud/devspace/pkg/devspace/build/builder/helper"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/generated"
@@ -173,7 +174,7 @@ func (b *Builder) BuildImage(contextPath, dockerfilePath string, entrypoint []st
 
 	// Check if we should overwrite entrypoint
 	if len(entrypoint) > 0 || len(cmd) > 0 || b.helper.ImageConf.InjectRestartHelper {
-		dockerfilePath, err = helper.RewriteDockerfile(dockerfilePath, entrypoint, cmd, options.Target, b.helper.ImageConf.InjectRestartHelper)
+		dockerfilePath, err = helper.RewriteDockerfile(dockerfilePath, entrypoint, cmd, options.Target, b.helper.ImageConf.InjectRestartHelper, log)
 		if err != nil {
 			return err
 		}

--- a/pkg/devspace/build/builder/helper/util.go
+++ b/pkg/devspace/build/builder/helper/util.go
@@ -117,10 +117,9 @@ func RewriteDockerfile(dockerfile string, entrypoint []string, cmd []string, tar
 		if len(entrypoint) == 0 {
 			if len(oldEntrypoint) == 0 {
 				if len(oldCmd) == 0 {
-					return "", errors.Errorf("Cannot inject restart helper into Dockerfile because neither ENTRYPOINT nor CMD was found.\n\nHow to fix this:\n- Option A: Define an ENTRYPOINT (or CMD) in your Dockerfile\n- Option B: Set `images.*.entrypoint` option in your devspace.yaml")
-				} else {
-					log.Warn("Using CMD statement for injecting restart helper because ENTRYPOINT is missing in Dockerfile and `images.*.entrypoint` is also not configured")
+					return "", errors.Errorf("cannot inject restart helper into Dockerfile because neither ENTRYPOINT nor CMD was found.\n\nHow to fix this:\n- Option A: Define an ENTRYPOINT (or CMD) in your Dockerfile\n- Option B: Set `images.*.entrypoint` option in your devspace.yaml")
 				}
+				log.Warn("Using CMD statement for injecting restart helper because ENTRYPOINT is missing in Dockerfile and `images.*.entrypoint` is also not configured")
 			}
 
 			entrypoint = oldEntrypoint

--- a/pkg/devspace/build/builder/helper/util.go
+++ b/pkg/devspace/build/builder/helper/util.go
@@ -171,23 +171,31 @@ func CreateTempDockerfile(dockerfile string, entrypoint []string, cmd []string, 
 
 // GetDockerfileTargets returns an array of names of all targets defined in a given Dockerfile
 func GetDockerfileTargets(dockerfile string) ([]string, error) {
+	targets := []string{}
+
 	if dockerfile == "" {
 		dockerfile = DefaultDockerfilePath
 	}
 
 	data, err := ioutil.ReadFile(dockerfile)
 	if err != nil {
-		return []string{}, err
+		return targets, err
 	}
 	content := string(data)
 
 	// Find all targets
 	targetFinder, err := regexp.Compile(fmt.Sprintf(DockerfileTargetRegexTemplate, "\\S+"))
 	if err != nil {
-		return []string{}, err
+		return targets, err
 	}
 
-	return targetFinder.FindAllString(content, -1), nil
+	rawTargets := targetFinder.FindAllStringSubmatch(content, -1)
+
+	for _, target := range rawTargets {
+		targets = append(targets, target[3])
+	}
+
+	return targets, nil
 }
 
 var nextFromFinder = regexp.MustCompile("(?i)\n\\s*FROM")

--- a/pkg/devspace/build/builder/helper/util.go
+++ b/pkg/devspace/build/builder/helper/util.go
@@ -24,7 +24,7 @@ import (
 const DefaultDockerfilePath = "./Dockerfile"
 
 // DockerfileTargetRegexTemplate is a template for a regex that finds build targets in a Dockerfile
-const DockerfileTargetRegexTemplate = "(?i)(^|\n)\\s*FROM\\s+([a-zA-Z0-9\\:\\@\\.\\-]+)\\s+AS\\s+(%s)\\s*($|\n)"
+const DockerfileTargetRegexTemplate = "(?i)(^|\n)\\s*FROM\\s+([a-zA-Z0-9/\\:\\@\\.\\-]+)\\s+AS\\s+(%s)\\s*($|\n)"
 
 // DefaultContextPath is the default context path to use
 const DefaultContextPath = "./"

--- a/pkg/devspace/build/builder/kaniko/kaniko.go
+++ b/pkg/devspace/build/builder/kaniko/kaniko.go
@@ -3,8 +3,9 @@ package kaniko
 import (
 	"io"
 	"io/ioutil"
-	"k8s.io/client-go/util/exec"
 	"strings"
+
+	"k8s.io/client-go/util/exec"
 
 	"github.com/devspace-cloud/devspace/pkg/devspace/build/builder"
 	"github.com/devspace-cloud/devspace/pkg/devspace/build/builder/helper"
@@ -159,7 +160,7 @@ func (b *Builder) BuildImage(contextPath, dockerfilePath string, entrypoint []st
 
 	// Check if we should overwrite entrypoint
 	if len(entrypoint) > 0 || len(cmd) > 0 || b.helper.ImageConf.InjectRestartHelper {
-		dockerfilePath, err = helper.RewriteDockerfile(dockerfilePath, entrypoint, cmd, options.Target, b.helper.ImageConf.InjectRestartHelper)
+		dockerfilePath, err = helper.RewriteDockerfile(dockerfilePath, entrypoint, cmd, options.Target, b.helper.ImageConf.InjectRestartHelper, log)
 		if err != nil {
 			return err
 		}

--- a/pkg/devspace/build/builder/restart/restart.go
+++ b/pkg/devspace/build/builder/restart/restart.go
@@ -43,8 +43,8 @@ while true; do
 
     if [ "$i" -lt 10 ]; then
       rm -f /devspace-pid
-      echo "\nRestart failed. Will retry in 3 seconds..."
-      sleep 3
+      echo "\nRestart failed. Will retry in 5 seconds..."
+      sleep 5
     fi
 
     set +e

--- a/pkg/devspace/build/builder/restart/restart.go
+++ b/pkg/devspace/build/builder/restart/restart.go
@@ -15,7 +15,7 @@ const ProcessIDFilePath = "/devspace-pid"
 // HelperScript is the content of the restart script in the container
 const HelperScript = `#!/bin/sh
 #
-# A process wrapper script to simulate a container restart. This file was injected with devspace during the build process
+# A process wrapper script to simulate a container restart. This file was injected by DevSpace during the build process
 #
 
 set -e
@@ -41,6 +41,6 @@ while true; do
     if [ -f /devspace-pid ]; then
         exit $exit_code
     fi
-    echo "Restart container"
+    echo "Restart container..."
 done
 `

--- a/pkg/devspace/build/builder/restart/restart.go
+++ b/pkg/devspace/build/builder/restart/restart.go
@@ -33,14 +33,29 @@ quit() {
 while true; do
     setsid "$@" &
     pid=$!
-    echo "$pid" > /devspace-pid
+    echo "$pid" >/devspace-pid
+
+    i=0
+    while kill -0 "$pid" >/dev/null 2>&1 && [ "$i" -lt 10 ]; do
+      sleep 0.1
+      i=$((i+1))
+    done
+
+    if [ "$i" -lt 10 ]; then
+      rm -f /devspace-pid
+      echo "\nRestart failed. Will retry in 3 seconds..."
+      sleep 3
+    fi
+
     set +e
     wait $pid
     exit_code=$?
     set -e
+
     if [ -f /devspace-pid ]; then
         exit $exit_code
     fi
-    echo "Restart container..."
+
+    echo "\nRestart container..."
 done
 `

--- a/pkg/devspace/build/builder/restart/restart.go
+++ b/pkg/devspace/build/builder/restart/restart.go
@@ -43,7 +43,7 @@ while true; do
 
     if [ "$i" -lt 10 ]; then
       rm -f /devspace-pid
-      echo "\nRestart failed. Will retry in 5 seconds..."
+      printf "\nRestart failed. Will retry in 5 seconds..."
       sleep 5
     fi
 
@@ -56,6 +56,6 @@ while true; do
         exit $exit_code
     fi
 
-    echo "\nRestart container..."
+    printf "\nRestart container...\n"
 done
 `

--- a/pkg/devspace/configure/image.go
+++ b/pkg/devspace/configure/image.go
@@ -183,7 +183,7 @@ func (m *manager) newImageConfigFromDockerfile(imageName, dockerfile, context st
 		targetNone := "[none] (build complete Dockerfile)"
 		targets = append(targets, targetNone)
 		target, err := m.log.Question(&survey.QuestionOptions{
-			Question: "Which target within your Dockerfile do you want to use for development?",
+			Question: "Which build stage (target) within your Dockerfile do you want to use for development?\n  Choose `build` for quickstart projects.",
 			Options:  targets,
 		})
 		if err != nil {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others)  
/kind enhancement


**What is this pull request for? Which issues does it resolve?** (use `resolves #<issue_number>` if possible)  
- uses CMD for restart helper if ENTRYPOINT not found/defined because that works for most images (e.g. all language specific images) and using CMD instead of ENTRYPOINT is recommended by Docker because ENTRYPOINT is supposed to just be a shell according to Docker best practices. if that is the best practice, we should just warn about using CMD without knowing ENTRYPOINT but not fail because we can assume that most images have a simple shell in ENTRYPOINT
- init now sets restartContainer, preferSyncOverRebuild, injectRestartHelper, production profile and build.docker.options.target (if multi-stage dockerfile)
- improves restart helper script to retry when immediate start script execution fails (important for many web servers who still have open connections that need a bit more time to terminate after KILL)
- fixes dockerfile target split regex


**Does this pull request has user-facing changes?** (e.g. config changes, new/modified commands, new/modified flags)  


**Does this pull request add new dependencies?**  


**What else do we need to know?**  
