### PR TITLE
fix config copy issue with kaniko fallback

### DIFF
--- a/pkg/devspace/build/builder/restart/restart.go
+++ b/pkg/devspace/build/builder/restart/restart.go
@@ -37,10 +37,17 @@ while true; do
     set +e
     wait $pid
     exit_code=$?
-    set -e
     if [ -f /devspace-pid ]; then
-        exit $exit_code
+		# if the sync is currently active we try to restart instead of exiting
+		if [ -f /tmp/sync ]; then
+			rm -f /devspace-pid 	
+			printf "\nContainer exited with $exit_code. Will restart in 3 seconds...\n"
+			sleep 3
+		else
+			exit $exit_code
+		fi
     fi
-    echo "Restart container"
+    set -e
+    printf "\nRestart container\n"
 done
 `

--- a/pkg/devspace/build/create_builder.go
+++ b/pkg/devspace/build/create_builder.go
@@ -97,13 +97,15 @@ func convertDockerConfigToKanikoConfig(dockerConfig *latest.ImageConfig) *latest
 	}
 
 	kanikoConfig := &latest.ImageConfig{
-		Image:            dockerConfig.Image,
-		Tags:             dockerConfig.Tags,
-		Dockerfile:       dockerConfig.Dockerfile,
-		Context:          dockerConfig.Context,
-		Entrypoint:       dockerConfig.Entrypoint,
-		Cmd:              dockerConfig.Cmd,
-		CreatePullSecret: dockerConfig.CreatePullSecret,
+		Image:                 dockerConfig.Image,
+		Tags:                  dockerConfig.Tags,
+		Dockerfile:            dockerConfig.Dockerfile,
+		Context:               dockerConfig.Context,
+		Entrypoint:            dockerConfig.Entrypoint,
+		Cmd:                   dockerConfig.Cmd,
+		PreferSyncOverRebuild: dockerConfig.PreferSyncOverRebuild,
+		InjectRestartHelper:   dockerConfig.InjectRestartHelper,
+		CreatePullSecret:      dockerConfig.CreatePullSecret,
 		Build: &latest.BuildConfig{
 			Kaniko: kanikoBuildOptions,
 		},


### PR DESCRIPTION
## Changes
- The restart script now always restarts the container process instead of exiting when sync is active in the container.
- Fixes an issue where the docker config was not correctly copied on kaniko fallback