### PR TITLE
Fix devspace cloud .env issue & warning instead of fatal

### DIFF
--- a/cmd/flags/flags.go
+++ b/cmd/flags/flags.go
@@ -6,7 +6,6 @@ import (
 	"github.com/devspace-cloud/devspace/pkg/util/log"
 	"github.com/mgutz/ansi"
 
-	"github.com/pkg/errors"
 	flag "github.com/spf13/pflag"
 )
 
@@ -27,13 +26,7 @@ type GlobalFlags struct {
 
 // UseLastContext uses the last context
 func (gf *GlobalFlags) UseLastContext(generatedConfig *generated.Config, log log.Logger) error {
-	if gf.KubeContext != "" && gf.SwitchContext {
-		return errors.Errorf("Flag --kube-context cannot be used together with --switch-context")
-	} else if gf.Namespace != "" && gf.SwitchContext {
-		return errors.Errorf("Flag --namespace cannot be used together with --switch-context")
-	}
-
-	if gf.SwitchContext == true {
+	if gf.KubeContext == "" && gf.Namespace == "" && gf.SwitchContext == true {
 		if generatedConfig == nil || generatedConfig.GetActive().LastContext == nil {
 			log.Warn("There is no last context to use. Only use the '--switch-context / -s' flag if you already have deployed the project before")
 		} else {

--- a/cmd/flags/flags_test.go
+++ b/cmd/flags/flags_test.go
@@ -21,22 +21,6 @@ type useLastContextTestCase struct {
 func TestUseLastContext(t *testing.T) {
 	testCases := []useLastContextTestCase{
 		useLastContextTestCase{
-			name: "Kube-Context and switch-context",
-			globalFlags: GlobalFlags{
-				KubeContext:   " ",
-				SwitchContext: true,
-			},
-			expectedErr: "Flag --kube-context cannot be used together with --switch-context",
-		},
-		useLastContextTestCase{
-			name: "Namespace and switch-context",
-			globalFlags: GlobalFlags{
-				Namespace:     " ",
-				SwitchContext: true,
-			},
-			expectedErr: "Flag --namespace cannot be used together with --switch-context",
-		},
-		useLastContextTestCase{
 			name: "Switch context to existent",
 			globalFlags: GlobalFlags{
 				SwitchContext: true,

--- a/pkg/util/flags/flags.go
+++ b/pkg/util/flags/flags.go
@@ -3,13 +3,12 @@ package flags
 import (
 	"errors"
 	"fmt"
-	"github.com/devspace-cloud/devspace/pkg/util/log"
 	"os"
 	"strings"
 )
 
 type Flags interface {
-	Apply(log log.Logger)
+	Apply() []string
 	Parse(command string) error
 }
 
@@ -24,16 +23,16 @@ func New() Flags {
 }
 
 // Apply appends the flags to the os.Args
-func (f *flags) Apply(log log.Logger) {
+func (f *flags) Apply() []string {
 	if len(f.args) == 0 {
-		return
+		return nil
 	}
 
-	log.Infof("Applying extra flags from environment: %s", strings.Join(f.args, " "))
 	newArgs := []string{os.Args[0]}
 	newArgs = append(newArgs, f.args...)
 	newArgs = append(newArgs, os.Args[1:]...)
 	os.Args = newArgs
+	return f.args
 }
 
 // Parse args parses the flags for a certain command from the environment variables


### PR DESCRIPTION
## Change
- If the `.env` file cannot be loaded, devspace will only print a warning instead of a fatal
- The flags `--switch-context`, `--namespace` and `--kube-context` can now be used together. `--kube-context` and `--namespace` take precedence over `--switch-context`
- Fixes an issue where the `.env` file could cause issues in combination with devspace-cloud spaces (#1068)
