### PR TITLE
Several Improvements

### DIFF
--- a/cmd/create/space.go
+++ b/cmd/create/space.go
@@ -8,6 +8,7 @@ import (
 	"github.com/devspace-cloud/devspace/pkg/util/factory"
 	"github.com/devspace-cloud/devspace/pkg/util/log"
 	"github.com/devspace-cloud/devspace/pkg/util/survey"
+	"sort"
 
 	"github.com/mgutz/ansi"
 	"github.com/pkg/errors"
@@ -182,6 +183,8 @@ func getCluster(p cloud.Provider, logger log.Logger) (*latest.Cluster, error) {
 		for _, cluster := range connectedClusters {
 			clusterNames = append(clusterNames, cluster.Name)
 		}
+
+		sort.Strings(clusterNames)
 
 		// Check if there are non connected clusters
 		for _, cluster := range clusters {

--- a/cmd/dev.go
+++ b/cmd/dev.go
@@ -124,6 +124,7 @@ Open terminal instead of logs:
 
 	devCmd.Flags().BoolVar(&cmd.Wait, "wait", false, "If true will wait first for pods to be running or fails after given timeout")
 	devCmd.Flags().IntVar(&cmd.Timeout, "timeout", 120, "Timeout until dev should stop waiting and fail")
+
 	return devCmd
 }
 

--- a/cmd/enter.go
+++ b/cmd/enter.go
@@ -7,7 +7,6 @@ import (
 	"github.com/devspace-cloud/devspace/pkg/util/exit"
 	"github.com/devspace-cloud/devspace/pkg/util/factory"
 	"github.com/pkg/errors"
-
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/flags/flags.go
+++ b/cmd/flags/flags.go
@@ -22,6 +22,8 @@ type GlobalFlags struct {
 	Vars        []string
 
 	SwitchContext bool
+
+	Flags *flag.FlagSet
 }
 
 // UseLastContext uses the last context
@@ -55,7 +57,8 @@ func (gf *GlobalFlags) ToConfigOptions() *loader.ConfigOptions {
 // SetGlobalFlags applies the global flags
 func SetGlobalFlags(flags *flag.FlagSet) *GlobalFlags {
 	globalFlags := &GlobalFlags{
-		Vars: []string{},
+		Vars:  []string{},
+		Flags: flags,
 	}
 
 	flags.BoolVar(&globalFlags.NoWarn, "no-warn", false, "If true does not show any warning when deploying into a different namespace or kube-context than before")

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -193,7 +193,7 @@ func (cmd *RenderCmd) Run(f factory.Factory, cobraCmd *cobra.Command, args []str
 	err = f.NewDeployController(config, generatedConfig.GetActive(), client).Render(&deploy.Options{
 		BuiltImages: builtImages,
 		Deployments: deployments,
-	}, os.Stdout)
+	}, os.Stdout, log)
 	if err != nil {
 		return err
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -47,7 +47,7 @@ func NewRootCmd(f factory.Factory) *cobra.Command {
 			// apply extra flags
 			extraFlags, err := flagspkg.ApplyExtraFlags(cobraCmd)
 			if err != nil {
-				log.Fatalf("Error applying extra flags: %v", err)
+				log.Warnf("Error applying extra flags: %v", err)
 			} else if len(extraFlags) > 0 {
 				log.Infof("Applying extra flags from environment: %s", strings.Join(extraFlags, " "))
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,53 +17,39 @@ import (
 	"github.com/devspace-cloud/devspace/pkg/util/analytics/cloudanalytics"
 	"github.com/devspace-cloud/devspace/pkg/util/exit"
 	"github.com/devspace-cloud/devspace/pkg/util/factory"
-	"github.com/devspace-cloud/devspace/pkg/util/log"
+	flagspkg "github.com/devspace-cloud/devspace/pkg/util/flags"
 	"github.com/joho/godotenv"
-	homedir "github.com/mitchellh/go-homedir"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"os"
 	"strings"
 )
 
-var cfgFile string
-
 // NewRootCmd returns a new root command
 func NewRootCmd(f factory.Factory) *cobra.Command {
-	log := f.GetLog()
-	// we delay the output because we don't want to print things when we are silenced
-	warnings := []string{}
-
-	// parse the .env file
-	err := godotenv.Load()
-	if err != nil && os.IsNotExist(err) == false {
-		warnings = append(warnings, "Error loading .env: " + err.Error())
-	}
-
-	// parse the environment flags
-	extraFlags, err := parseEnvironmentFlags(f)
-	if err != nil {
-		warnings = append(warnings, "Error parsing environment variables: " + err.Error())
-	}
-
 	return &cobra.Command{
 		Use:           "devspace",
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Short:         "Welcome to the DevSpace!",
 		PersistentPreRun: func(cobraCmd *cobra.Command, args []string) {
+			log := f.GetLog()
 			if globalFlags.Silent {
 				log.SetLevel(logrus.FatalLevel)
 			}
 
-			if len(extraFlags) > 0 {
-				log.Infof("Applying extra flags from environment: %s", strings.Join(extraFlags, " "))
+			// parse the .env file
+			err := godotenv.Load()
+			if err != nil && os.IsNotExist(err) == false {
+				log.Warnf("Error loading .env: %v", err)
 			}
 
-			for _, warning := range warnings {
-				log.Warn(warning)
+			// apply extra flags
+			extraFlags, err := flagspkg.ApplyExtraFlags(cobraCmd)
+			if err != nil {
+				log.Fatalf("Error applying extra flags: %v", err)
+			} else if len(extraFlags) > 0 {
+				log.Infof("Applying extra flags from environment: %s", strings.Join(extraFlags, " "))
 			}
 
 			// Get version of current binary
@@ -151,48 +137,5 @@ func BuildRoot(f factory.Factory) *cobra.Command {
 	rootCmd.AddCommand(NewAttachCmd(f, globalFlags))
 	rootCmd.AddCommand(NewPrintCmd(f, globalFlags))
 
-	cobra.OnInitialize(func() { initConfig(f.GetLog()) })
 	return rootCmd
-}
-
-// initConfig reads in config file and ENV variables if set.
-func initConfig(log log.Logger) {
-	if cfgFile != "" {
-		// Use config file from the flag.
-		viper.SetConfigFile(cfgFile)
-	} else {
-		// Find home directory.
-		home, err := homedir.Dir()
-		if err != nil {
-			log.Panic(err)
-		}
-
-		// Search config in home directory with name ".devspace" (without extension).
-		viper.AddConfigPath(home)
-		viper.SetConfigName(".devspace")
-	}
-
-	viper.AutomaticEnv() // read in environment variables that match
-
-	// If a config file is found, read it in.
-	if err := viper.ReadInConfig(); err == nil {
-		log.Info("Using config file:", viper.ConfigFileUsed())
-	}
-}
-
-func parseEnvironmentFlags(f factory.Factory) ([]string, error) {
-	// new environment flags parser
-	flagsParser := f.NewEnvironmentFlagsParser()
-
-	// parse other commands
-	supportedCommands := []string{"", "analyze", "attach", "build", "deploy", "dev", "enter", "init", "login", "logs", "open", "print", "purge", "render", "run", "sync", "ui"}
-	for _, command := range supportedCommands {
-		err := flagsParser.Parse(command)
-		if err != nil {
-			return nil, errors.Wrap(err, "parse flags for command "+command)
-		}
-	}
-
-	// apply flags
-	return flagsParser.Apply(), nil
 }

--- a/cmd/use/context.go
+++ b/cmd/use/context.go
@@ -3,8 +3,6 @@ package use
 import (
 	"github.com/devspace-cloud/devspace/cmd/flags"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/loader"
-	"sort"
-
 	"github.com/devspace-cloud/devspace/pkg/util/factory"
 	"github.com/devspace-cloud/devspace/pkg/util/survey"
 
@@ -62,12 +60,11 @@ func (cmd *ContextCmd) RunUseContext(f factory.Factory, cobraCmd *cobra.Command,
 			contexts = append(contexts, ctx)
 		}
 
-		sort.Strings(contexts)
-
 		context, err = log.Question(&survey.QuestionOptions{
 			Question:     "Which context do you want to use?",
 			DefaultValue: kubeConfig.CurrentContext,
 			Options:      contexts,
+			Sort:         true,
 		})
 		if err != nil {
 			return err

--- a/cmd/use/namespace.go
+++ b/cmd/use/namespace.go
@@ -93,6 +93,7 @@ func (cmd *namespaceCmd) RunUseNamespace(f factory.Factory, cobraCmd *cobra.Comm
 		namespace, err = log.Question(&survey.QuestionOptions{
 			Question: "Which namespace do you want to use?",
 			Options:  namespaces,
+			Sort:     true,
 		})
 		if err != nil {
 			return err

--- a/cmd/use/provider.go
+++ b/cmd/use/provider.go
@@ -60,6 +60,7 @@ func (*providerCmd) RunUseProvider(f factory.Factory, cobraCmd *cobra.Command, a
 			Question:     "Please select a default provider",
 			DefaultValue: providerConfig.Default,
 			Options:      providerNames,
+			Sort:         true,
 		})
 		if err != nil {
 			return err

--- a/cmd/use/space.go
+++ b/cmd/use/space.go
@@ -96,6 +96,7 @@ func (cmd *spaceCmd) RunUseSpace(f factory.Factory, cobraCmd *cobra.Command, arg
 		spaceName, err := log.Question(&survey.QuestionOptions{
 			Question: "Please select the Space that you want to use",
 			Options:  names,
+			Sort:     true,
 		})
 		if err != nil {
 			return err

--- a/pkg/devspace/dependency/dependency.go
+++ b/pkg/devspace/dependency/dependency.go
@@ -317,7 +317,7 @@ func (d *Dependency) Render(skipPush, skipBuild, forceBuild bool, log log.Logger
 	// Deploy all defined deployments
 	return d.deployController.Render(&deploy.Options{
 		BuiltImages: builtImages,
-	}, os.Stdout)
+	}, os.Stdout, log)
 }
 
 // Purge purges the dependency

--- a/pkg/devspace/deploy/deploy.go
+++ b/pkg/devspace/deploy/deploy.go
@@ -30,7 +30,7 @@ type Options struct {
 // Controller is the main deploying interface
 type Controller interface {
 	Deploy(options *Options, log log.Logger) error
-	Render(options *Options, out io.Writer) error
+	Render(options *Options, out io.Writer, log log.Logger) error
 	Purge(deployments []string, log log.Logger) error
 }
 
@@ -53,7 +53,7 @@ func NewController(config *latest.Config, cache *generated.CacheConfig, client k
 	}
 }
 
-func (c *controller) Render(options *Options, out io.Writer) error {
+func (c *controller) Render(options *Options, out io.Writer, log log.Logger) error {
 	if c.config.Deployments != nil && len(c.config.Deployments) > 0 {
 		helmV2Clients := map[string]helmtypes.Client{}
 
@@ -79,19 +79,19 @@ func (c *controller) Render(options *Options, out io.Writer) error {
 			)
 
 			if deployConfig.Kubectl != nil {
-				deployClient, err = kubectl.New(c.config, c.client, deployConfig, log.Discard)
+				deployClient, err = kubectl.New(c.config, c.client, deployConfig, log)
 				if err != nil {
 					return errors.Errorf("Error render: deployment %s error: %v", deployConfig.Name, err)
 				}
 
 			} else if deployConfig.Helm != nil {
 				// Get helm client
-				helmClient, err := GetCachedHelmClient(c.config, deployConfig, c.client, helmV2Clients, true, log.Discard)
+				helmClient, err := GetCachedHelmClient(c.config, deployConfig, c.client, helmV2Clients, true, log)
 				if err != nil {
 					return errors.Wrap(err, "get cached helm client")
 				}
 
-				deployClient, err = helm.New(c.config, helmClient, c.client, deployConfig, log.Discard)
+				deployClient, err = helm.New(c.config, helmClient, c.client, deployConfig, log)
 				if err != nil {
 					return errors.Errorf("Error render: deployment %s error: %v", deployConfig.Name, err)
 				}

--- a/pkg/devspace/deploy/deploy_test.go
+++ b/pkg/devspace/deploy/deploy_test.go
@@ -76,7 +76,7 @@ func TestRender(t *testing.T) {
 			testCase.options = &Options{}
 		}
 
-		err := controller.Render(testCase.options, nil)
+		err := controller.Render(testCase.options, nil, log.Discard)
 
 		if testCase.expectedErr == "" {
 			assert.NilError(t, err, "Error in testCase %s", testCase.name)

--- a/pkg/devspace/deploy/deployer/kubectl/builder.go
+++ b/pkg/devspace/deploy/deployer/kubectl/builder.go
@@ -3,6 +3,7 @@ package kubectl
 import (
 	"fmt"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/versions/latest"
+	"github.com/devspace-cloud/devspace/pkg/util/log"
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -21,12 +22,14 @@ type RunCommand func(path string, args []string) ([]byte, error)
 type kustomizeBuilder struct {
 	path   string
 	config *latest.DeploymentConfig
+	log    log.Logger
 }
 
-func NewKustomizeBuilder(path string, config *latest.DeploymentConfig) Builder {
+func NewKustomizeBuilder(path string, config *latest.DeploymentConfig, log log.Logger) Builder {
 	return &kustomizeBuilder{
 		path:   path,
 		config: config,
+		log:    log,
 	}
 }
 
@@ -35,6 +38,7 @@ func (k *kustomizeBuilder) Build(manifest string, cmd RunCommand) ([]*unstructur
 	args = append(args, k.config.Kubectl.KustomizeArgs...)
 
 	// Execute command
+	k.log.Infof("Render manifests with 'kustomize %s'", strings.Join(args, " "))
 	output, err := cmd(k.path, args)
 	if err != nil {
 		exitError, ok := err.(*exec.ExitError)

--- a/pkg/devspace/deploy/deployer/kubectl/kubectl.go
+++ b/pkg/devspace/deploy/deployer/kubectl/kubectl.go
@@ -274,8 +274,8 @@ func (d *DeployConfig) getCmdArgs(method string, additionalArgs ...string) []str
 
 func (d *DeployConfig) buildManifests(manifest string) ([]*unstructured.Unstructured, error) {
 	// Check if we should use kustomize or kubectl
-	if d.DeploymentConfig.Kubectl.Kustomize != nil && *d.DeploymentConfig.Kubectl.Kustomize == true && d.isKustomizeInstalled("kustomize")  {
-		return NewKustomizeBuilder("kustomize", d.DeploymentConfig).Build(manifest, d.commandExecuter.RunCommand)
+	if d.DeploymentConfig.Kubectl.Kustomize != nil && *d.DeploymentConfig.Kubectl.Kustomize == true && d.isKustomizeInstalled("kustomize") {
+		return NewKustomizeBuilder("kustomize", d.DeploymentConfig, d.Log).Build(manifest, d.commandExecuter.RunCommand)
 	}
 
 	// Build with kubectl
@@ -288,5 +288,5 @@ func (d *DeployConfig) isKustomizeInstalled(path string) bool {
 		return false
 	}
 
-	return strings.HasPrefix(string(out), `Version: {Version:kustomize/`)
+	return strings.Index(string(out), `kustomize`) != -1
 }

--- a/pkg/devspace/deploy/testing/fake.go
+++ b/pkg/devspace/deploy/testing/fake.go
@@ -22,7 +22,7 @@ func (f *FakeController) Deploy(options *deploy.Options, log log.Logger) error {
 }
 
 // Render implements interface
-func (f *FakeController) Render(options *deploy.Options, out io.Writer) error {
+func (f *FakeController) Render(options *deploy.Options, out io.Writer, log log.Logger) error {
 	return nil
 }
 

--- a/pkg/devspace/docker/auth.go
+++ b/pkg/devspace/docker/auth.go
@@ -130,23 +130,22 @@ func getDefaultAuthConfig(checkCredStore bool, serverAddress string, isDefaultRe
 		serverAddress = registry.ConvertToHostname(serverAddress)
 	}
 
+	authconfig.ServerAddress = serverAddress
 	if checkCredStore {
 		configfile, err := loadDockerConfig()
-
 		if configfile != nil && err == nil {
 			authconfigOrig, err := configfile.GetAuthConfig(serverAddress)
 			if err != nil {
-				return nil, err
+				return &authconfig, err
 			}
 
 			// convert
 			err = util.Convert(authconfigOrig, &authconfig)
 			if err != nil {
-				return nil, err
+				return &authconfig, err
 			}
 		}
 	}
 
-	authconfig.ServerAddress = serverAddress
 	return &authconfig, err
 }

--- a/pkg/devspace/docker/auth.go
+++ b/pkg/devspace/docker/auth.go
@@ -130,22 +130,24 @@ func getDefaultAuthConfig(checkCredStore bool, serverAddress string, isDefaultRe
 		serverAddress = registry.ConvertToHostname(serverAddress)
 	}
 
-	authconfig.ServerAddress = serverAddress
 	if checkCredStore {
 		configfile, err := loadDockerConfig()
 		if configfile != nil && err == nil {
 			authconfigOrig, err := configfile.GetAuthConfig(serverAddress)
 			if err != nil {
+				authconfig.ServerAddress = serverAddress
 				return &authconfig, err
 			}
 
 			// convert
 			err = util.Convert(authconfigOrig, &authconfig)
 			if err != nil {
+				authconfig.ServerAddress = serverAddress
 				return &authconfig, err
 			}
 		}
 	}
 
+	authconfig.ServerAddress = serverAddress
 	return &authconfig, err
 }

--- a/pkg/util/factory/factory.go
+++ b/pkg/util/factory/factory.go
@@ -20,7 +20,6 @@ import (
 	"github.com/devspace-cloud/devspace/pkg/devspace/registry"
 	"github.com/devspace-cloud/devspace/pkg/devspace/services"
 	"github.com/devspace-cloud/devspace/pkg/devspace/services/targetselector"
-	"github.com/devspace-cloud/devspace/pkg/util/flags"
 	"github.com/devspace-cloud/devspace/pkg/util/kubeconfig"
 	"github.com/devspace-cloud/devspace/pkg/util/log"
 )
@@ -29,9 +28,6 @@ import (
 type Factory interface {
 	// Config Loader
 	NewConfigLoader(options *loader.ConfigOptions, log log.Logger) loader.ConfigLoader
-
-	// Environment flags parser
-	NewEnvironmentFlagsParser() flags.Flags
 
 	// ConfigureManager
 	NewConfigureManager(config *latest.Config, log log.Logger) configure.Manager
@@ -86,11 +82,6 @@ type DefaultFactoryImpl struct{}
 // DefaultFactory returns the default factory implementation
 func DefaultFactory() Factory {
 	return &DefaultFactoryImpl{}
-}
-
-// NewEnvironmentFlagsParser returns a new environemnt flags parser
-func (f *DefaultFactoryImpl) NewEnvironmentFlagsParser() flags.Flags {
-	return flags.New()
 }
 
 // NewAnalyzer creates a new analyzer

--- a/pkg/util/factory/testing/factory.go
+++ b/pkg/util/factory/testing/factory.go
@@ -20,7 +20,6 @@ import (
 	"github.com/devspace-cloud/devspace/pkg/devspace/services"
 	"github.com/devspace-cloud/devspace/pkg/devspace/services/targetselector"
 	"github.com/devspace-cloud/devspace/pkg/util/factory"
-	"github.com/devspace-cloud/devspace/pkg/util/flags"
 	"github.com/devspace-cloud/devspace/pkg/util/kubeconfig"
 	"github.com/devspace-cloud/devspace/pkg/util/log"
 )
@@ -47,11 +46,6 @@ type Factory struct {
 	ServicesClient    services.Client
 	Provider          cloud.Provider
 	Resumer           resume.SpaceResumer
-}
-
-// NewEnvironmentFlagsParser implements the interface
-func (f *Factory) NewEnvironmentFlagsParser() flags.Flags {
-	return nil
 }
 
 // NewAnalyzer creates a new analyzer

--- a/pkg/util/flags/flags.go
+++ b/pkg/util/flags/flags.go
@@ -23,6 +23,9 @@ func ApplyExtraFlags(cobraCmd *cobra.Command) ([]string, error) {
 	}
 
 	flags = append(flags, commandFlags...)
+	if len(flags) == 0 {
+		return nil, nil
+	}
 
 	err = cobraCmd.ParseFlags(flags)
 	if err != nil {

--- a/pkg/util/survey/survey.go
+++ b/pkg/util/survey/survey.go
@@ -3,6 +3,7 @@ package survey
 import (
 	"os"
 	"regexp"
+	"sort"
 
 	"github.com/pkg/errors"
 	surveypkg "gopkg.in/AlecAivazis/survey.v1"
@@ -16,6 +17,7 @@ type QuestionOptions struct {
 	ValidationMessage      string
 	ValidationFunc         func(value string) error
 	Options                []string
+	Sort                   bool
 	IsPassword             bool
 }
 
@@ -43,6 +45,11 @@ func (s *survey) Question(params *QuestionOptions) (string, error) {
 	}
 
 	if params.Options != nil {
+		if params.Sort {
+			params.Options = copyStringArray(params.Options)
+			sort.Strings(params.Options)
+		}
+
 		prompt = &surveypkg.Select{
 			Message: params.Question + "\n",
 			Options: params.Options,
@@ -110,4 +117,12 @@ func (s *survey) Question(params *QuestionOptions) (string, error) {
 	}
 
 	return answers.Question, nil
+}
+
+func copyStringArray(strings []string) []string {
+	retStrings := []string{}
+	for _, str := range strings {
+		retStrings = append(retStrings, str)
+	}
+	return retStrings
 }


### PR DESCRIPTION
## Changes
- Improves the environment flag parsing. Environment flags can now also be set for every command (e.g. `devspace create space` -> DEVSPACE_CREATE_SPACE_FLAGS)
- Fixes an issue where devspace was not correctly parsing command arguments (#977)
- Fixes a nil pointer in the docker authentification (#1076)
- Fixes an issue where devspace was parsing `kustomize version` incorrectly for newer versions (#859)