### PR TITLE
Implements #1166, #1165, #1163 and #1160

### DIFF
--- a/cmd/dev.go
+++ b/cmd/dev.go
@@ -448,7 +448,7 @@ func (cmd *DevCmd) startServices(f factory.Factory, config *latest.Config, gener
 		defer logger.StopWait()
 
 		// Create server
-		server, err := server.NewServer(cmd.configLoader, config, generatedConfig, false, client.CurrentContext(), client.Namespace(), nil, logger)
+		server, err := server.NewServer(cmd.configLoader, config, generatedConfig, "localhost", false, client.CurrentContext(), client.Namespace(), nil, logger)
 		if err != nil {
 			logger.Warnf("Couldn't start UI server: %v", err)
 		} else {

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -45,7 +45,9 @@ type OpenCmd struct {
 	*flags.GlobalFlags
 
 	Provider string
-	log      log.Logger
+	Port     int
+
+	log log.Logger
 }
 
 // NewOpenCmd creates a new open command
@@ -75,6 +77,7 @@ devspace open
 	}
 
 	openCmd.Flags().StringVar(&cmd.Provider, "provider", "", "The cloud provider to use")
+	openCmd.Flags().IntVar(&cmd.Port, "port", 0, "The cloud provider to use")
 
 	return openCmd
 }
@@ -129,16 +132,6 @@ func (cmd *OpenCmd) RunOpen(f factory.Factory, plugins []plugin.Metadata, cobraC
 		return err
 	}
 
-	// Get default namespace
-	var devspaceConfig *latest.Config
-	if configExists {
-		// Get config with adjusted cluster config
-		devspaceConfig, err = configLoader.Load()
-		if err != nil {
-			return err
-		}
-	}
-
 	namespace := client.Namespace()
 	ingressControllerWarning = ansi.Color(" ! an ingress controller must be installed in your cluster", "red+b")
 
@@ -157,7 +150,7 @@ func (cmd *OpenCmd) RunOpen(f factory.Factory, plugins []plugin.Metadata, cobraC
 
 	// Check if we should open locally
 	if openingMode == openLocalHostOption {
-		cmd.openLocal(f, devspaceConfig, nil, client, domain)
+		cmd.openLocal(f, nil, client, domain)
 		return nil
 	}
 
@@ -177,7 +170,7 @@ func (cmd *OpenCmd) RunOpen(f factory.Factory, plugins []plugin.Metadata, cobraC
 
 	// No suitable ingress found => create ingress
 	if existingIngressDomain == "" {
-		serviceName, servicePort, _, err := cmd.getService(devspaceConfig, client, namespace, domain, false)
+		serviceName, servicePort, _, err := cmd.getService(client, namespace, domain, false)
 		if err != nil {
 			return errors.Wrap(err, "get service")
 		}
@@ -273,26 +266,29 @@ func openURL(url string, kubectlClient kubectl.Client, analyzeNamespace string, 
 	return nil
 }
 
-func (cmd *OpenCmd) openLocal(f factory.Factory, devspaceConfig *latest.Config, generatedConfig *generated.Config, client kubectl.Client, domain string) error {
-	_, servicePort, serviceLabels, err := cmd.getService(devspaceConfig, client, client.Namespace(), domain, true)
+func (cmd *OpenCmd) openLocal(f factory.Factory, generatedConfig *generated.Config, client kubectl.Client, domain string) error {
+	_, servicePort, serviceLabels, err := cmd.getService(client, client.Namespace(), domain, true)
 	if err != nil {
 		return errors.Errorf("Unable to get service: %v", err)
 	}
 
 	localPort := servicePort
-	if localPort < 1024 {
-		localPort = localPort + 8000
-	}
+	if cmd.Port != 0 {
+		localPort = cmd.Port
+	} else {
+		if localPort < 1024 {
+			localPort = localPort + 8000
+		}
 
-	// Check if port is open
-	portOpen, _ := port.Check(localPort)
-	for portOpen == false {
-		localPort++
-		portOpen, _ = port.Check(localPort)
+		// Check if port is open
+		portOpen, _ := port.Check(localPort)
+		for portOpen == false {
+			localPort++
+			portOpen, _ = port.Check(localPort)
+		}
 	}
 
 	domain = "http://localhost:" + strconv.Itoa(localPort)
-
 	portMappings := []*latest.PortMapping{
 		&latest.PortMapping{
 			LocalPort:  &localPort,
@@ -331,7 +327,7 @@ func (cmd *OpenCmd) openLocal(f factory.Factory, devspaceConfig *latest.Config, 
 	time.Sleep(time.Second * 2)
 
 	cmd.log.StopWait()
-	open.Start(domain)
+	_ = open.Start(domain)
 	cmd.log.Donef("Successfully opened %s", domain)
 	cmd.log.WriteString("\n")
 	cmd.log.Info("Press ENTER to terminate port-forwarding process")
@@ -342,7 +338,7 @@ func (cmd *OpenCmd) openLocal(f factory.Factory, devspaceConfig *latest.Config, 
 	return nil
 }
 
-func (cmd *OpenCmd) getService(config *latest.Config, client kubectl.Client, namespace, host string, getEndpoints bool) (string, int, *map[string]string, error) {
+func (cmd *OpenCmd) getService(client kubectl.Client, namespace, host string, getEndpoints bool) (string, int, *map[string]string, error) {
 	// Let user select service
 	serviceNameList := []string{}
 	serviceLabels := map[string]map[string]string{}
@@ -365,10 +361,10 @@ func (cmd *OpenCmd) getService(config *latest.Config, client kubectl.Client, nam
 
 			for _, ports := range service.Spec.Ports {
 				port := ports.Port
-
 				if getEndpoints {
 					port = ports.TargetPort.IntVal
 				}
+
 				serviceNameList = append(serviceNameList, service.Name+":"+strconv.Itoa(int(port)))
 			}
 

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -77,7 +77,7 @@ devspace open
 	}
 
 	openCmd.Flags().StringVar(&cmd.Provider, "provider", "", "The cloud provider to use")
-	openCmd.Flags().IntVar(&cmd.Port, "port", 0, "The cloud provider to use")
+	openCmd.Flags().IntVar(&cmd.Port, "port", 0, "The port on the localhost to listen on")
 
 	return openCmd
 }

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -73,7 +73,7 @@ func (cmd *UICmd) RunUI(f factory.Factory, cobraCmd *cobra.Command, args []strin
 	}
 
 	// Search for an already existing server
-	if cmd.ForceServer == false && cmd.Dev == false {
+	if cmd.ForceServer == false && cmd.Dev == false && cmd.Host == "localhost" {
 		checkPort := server.DefaultPort
 		if cmd.Port != 0 {
 			checkPort = cmd.Port

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -25,6 +25,7 @@ type UICmd struct {
 
 	Dev bool
 
+	Host        string
 	Port        int
 	ForceServer bool
 
@@ -54,7 +55,8 @@ Opens the localhost UI in the browser
 		},
 	}
 
-	uiCmd.Flags().IntVar(&cmd.Port, "port", 0, "The port to use when opening the server")
+	uiCmd.Flags().StringVar(&cmd.Host, "host", "localhost", "The host to use when opening the ui server")
+	uiCmd.Flags().IntVar(&cmd.Port, "port", 0, "The port to use when opening the ui server")
 	uiCmd.Flags().BoolVar(&cmd.ForceServer, "server", false, "If enabled will force start a server (otherwise an existing UI server is searched)")
 	uiCmd.Flags().BoolVar(&cmd.Dev, "dev", false, "Ignore errors when downloading UI")
 	return uiCmd
@@ -78,13 +80,13 @@ func (cmd *UICmd) RunUI(f factory.Factory, cobraCmd *cobra.Command, args []strin
 		}
 
 		for i := 0; i < 20; i++ {
-			unused, err := port.CheckHostPort("localhost", checkPort)
+			unused, err := port.CheckHostPort(cmd.Host, checkPort)
 			if unused == false {
 				if i+1 == 20 {
 					return errors.Wrap(err, "check for open port")
 				}
 
-				domain := fmt.Sprintf("http://localhost:%d", checkPort)
+				domain := fmt.Sprintf("http://%s:%d", cmd.Host, checkPort)
 
 				// Check if DevSpace server
 				response, err := http.Get(domain + "/api/version")
@@ -186,7 +188,7 @@ func (cmd *UICmd) RunUI(f factory.Factory, cobraCmd *cobra.Command, args []strin
 	}
 
 	// Create server
-	server, err := server.NewServer(configLoader, config, generatedConfig, cmd.Dev, client.CurrentContext(), client.Namespace(), forcePort, cmd.log)
+	server, err := server.NewServer(configLoader, config, generatedConfig, cmd.Host, cmd.Dev, client.CurrentContext(), client.Namespace(), forcePort, cmd.log)
 	if err != nil {
 		return err
 	}
@@ -195,7 +197,7 @@ func (cmd *UICmd) RunUI(f factory.Factory, cobraCmd *cobra.Command, args []strin
 	if cmd.Dev == false {
 		go func(domain string) {
 			time.Sleep(time.Second * 2)
-			open.Start("http://" + domain)
+			_ = open.Start("http://" + domain)
 		}(server.Server.Addr)
 	}
 

--- a/examples/dependencies/dependency1/devspace.yaml
+++ b/examples/dependencies/dependency1/devspace.yaml
@@ -1,7 +1,7 @@
 version: v1beta8
 images:
   default:
-    image: dscr.io/${DEVSPACE_USERNAME}/devspace
+    image: mydockeruser/devspace
     createPullSecret: true
 deployments:
 - name: dependency1
@@ -9,7 +9,7 @@ deployments:
     componentChart: true
     values:
       containers:
-      - image: dscr.io/${DEVSPACE_USERNAME}/devspace
+      - image: mydockeruser/devspace
 dependencies:
 - source:
     path: ../dependency2

--- a/examples/hooks/devspace.yaml
+++ b/examples/hooks/devspace.yaml
@@ -1,14 +1,14 @@
-version: v1beta5
+version: v1beta9
 images:
   default:
-    image: dscr.io/${DEVSPACE_USERNAME}/devspace
+    image: mydockeruser/devspace
 deployments:
 - name: my-deployment
   helm:
     componentChart: true
     values:
       containers:
-      - image: dscr.io/${DEVSPACE_USERNAME}/devspace
+      - image: mydockeruser/devspace
 hooks:
 - command: echo
   args:

--- a/examples/kustomize/devspace.yaml
+++ b/examples/kustomize/devspace.yaml
@@ -1,4 +1,4 @@
-version: v1beta5
+version: v1beta9
 images:
   default:
     image: yourusername/devspace

--- a/examples/microservices/devspace.yaml
+++ b/examples/microservices/devspace.yaml
@@ -2,7 +2,7 @@
 # If you want to try this example in other
 # Clusters you have to exchange the image names
 # and enable image pushing
-version: v1beta5
+version: v1beta9
 images:
   node:
     image: node

--- a/examples/minikube/devspace.yaml
+++ b/examples/minikube/devspace.yaml
@@ -1,4 +1,4 @@
-version: v1beta5
+version: v1beta9
 images:
   default:
     image: devspace

--- a/examples/php-mysql-example/devspace.yaml
+++ b/examples/php-mysql-example/devspace.yaml
@@ -1,7 +1,7 @@
-version: v1beta5
+version: v1beta9
 images:
   default:
-    image: dscr.io/${DEVSPACE_USERNAME}/devspace
+    image: mydockeruser/devspace
 deployments:
 - name: mysql
   helm:
@@ -31,7 +31,7 @@ deployments:
     componentChart: true
     values:
       containers:
-      - image: dscr.io/${DEVSPACE_USERNAME}/devspace
+      - image: mydockeruser/devspace
       service:
         ports:
         - port: 80

--- a/examples/profiles/devspace.yaml
+++ b/examples/profiles/devspace.yaml
@@ -1,12 +1,12 @@
 version: v1beta5
 images:
   service-image-1:
-    image: dscr.io/${DEVSPACE_USERNAME}/service-1
+    image: mydockeruser/service-1
     dockerfile: service1/Dockerfile
     context: service1/
     createPullSecret: true
   service-image-2:
-    image: dscr.io/${DEVSPACE_USERNAME}/service-2
+    image: mydockeruser/service-2
     dockerfile: service2/Dockerfile
     context: service2/
     createPullSecret: true
@@ -16,13 +16,13 @@ deployments:
       componentChart: true
       values:
         containers:
-          - image: dscr.io/${DEVSPACE_USERNAME}/service-1
+          - image: mydockeruser/service-1
   - name: service-2
     helm:
       componentChart: true
       values:
         containers:
-          - image: dscr.io/${DEVSPACE_USERNAME}/service-2
+          - image: mydockeruser/service-2
 commands:
   - name: dev-service1
     command: "devspace dev --profile=dev-service1"

--- a/examples/quickstart-kubectl/devspace.yaml
+++ b/examples/quickstart-kubectl/devspace.yaml
@@ -1,7 +1,7 @@
-version: v1beta5
+version: v1beta9
 images:
   default:
-    image: dscr.io/yourusername/quickstart
+    image: mydockeruser/quickstart
 deployments:
 - name: devspace-default
   kubectl:

--- a/examples/quickstart-kubectl/kube/deployment.yaml
+++ b/examples/quickstart-kubectl/kube/deployment.yaml
@@ -17,4 +17,4 @@ spec:
       containers:
         - name: default
           # The correct image tag will be inserted during devspace dev / devspace deploy
-          image: dscr.io/yourusername/quickstart
+          image: mydockeruser/quickstart

--- a/examples/redeploy-instead-of-hot-reload/devspace.yaml
+++ b/examples/redeploy-instead-of-hot-reload/devspace.yaml
@@ -1,4 +1,4 @@
-version: v1beta5
+version: v1beta9
 images:
   default:
     image: yourusername/devspace

--- a/pkg/devspace/config/loader/get.go
+++ b/pkg/devspace/config/loader/get.go
@@ -121,10 +121,16 @@ func (l *configLoader) New() *latest.Config {
 
 // ConfigOptions defines options to load the config
 type ConfigOptions struct {
-	Profile     string
 	KubeContext string
 	Namespace   string
-	ConfigPath  string
+
+	// The path the config should be loaded from (e.g. /test/devspace.yaml)
+	ConfigPath string
+	// If the config is loaded from a dependency, this points to the original
+	// path where the base config was loaded from
+	BasePath string
+	// The profile that should be loaded
+	Profile string
 
 	GeneratedConfig *generated.Config
 	LoadedVars      map[string]string

--- a/pkg/devspace/config/loader/predefined_vars.go
+++ b/pkg/devspace/config/loader/predefined_vars.go
@@ -24,11 +24,23 @@ var predefinedVars = map[string]func(loader *configLoader) (string, error){
 
 		return ret, nil
 	},
+	"DEVSPACE_PROFILE": func(loader *configLoader) (string, error) {
+		if loader.options == nil {
+			return "", nil
+		}
+
+		return loader.options.Profile, nil
+	},
 	"DEVSPACE_TIMESTAMP": func(loader *configLoader) (string, error) {
 		return strconv.FormatInt(time.Now().Unix(), 10), nil
 	},
 	"DEVSPACE_GIT_COMMIT": func(loader *configLoader) (string, error) {
-		hash, err := git.GetHash(filepath.Dir(loader.ConfigPath()))
+		configPath := loader.options.BasePath
+		if configPath == "" {
+			configPath = loader.ConfigPath()
+		}
+
+		hash, err := git.GetHash(filepath.Dir(configPath))
 		if err != nil {
 			return "", fmt.Errorf("No git repository found (%v), but predefined var DEVSPACE_GIT_COMMIT is used", err)
 		}

--- a/pkg/devspace/dependency/resolver.go
+++ b/pkg/devspace/dependency/resolver.go
@@ -254,6 +254,7 @@ func (r *resolver) resolveDependency(basePath string, dependency *latest.Depende
 	// Load config
 	cloned.GeneratedConfig = r.BaseCache
 	cloned.ConfigPath = configPath
+	cloned.BasePath = loader.NewConfigLoader(r.ConfigOptions, r.log).ConfigPath()
 
 	// Create the config loader
 	var dConfig *latest.Config

--- a/pkg/devspace/dependency/resolver.go
+++ b/pkg/devspace/dependency/resolver.go
@@ -230,9 +230,13 @@ func (r *resolver) resolveDependency(basePath string, dependency *latest.Depende
 			r.log.Donef("Pulled %s", ID)
 		}
 	} else if dependency.Source.Path != "" {
-		localPath, err = filepath.Abs(filepath.Join(basePath, filepath.FromSlash(dependency.Source.Path)))
-		if err != nil {
-			return nil, errors.Wrap(err, "filepath absolute")
+		if filepath.IsAbs(dependency.Source.Path) {
+			localPath = dependency.Source.Path
+		} else {
+			localPath, err = filepath.Abs(filepath.Join(basePath, filepath.FromSlash(dependency.Source.Path)))
+			if err != nil {
+				return nil, errors.Wrap(err, "filepath absolute")
+			}
 		}
 	}
 
@@ -362,7 +366,10 @@ func (r *resolver) getDependencyID(basePath string, dependency *latest.Dependenc
 		return id
 	} else if dependency.Source.Path != "" {
 		// Check if it's an git repo
-		filePath := filepath.Join(basePath, dependency.Source.Path)
+		filePath := dependency.Source.Path
+		if !filepath.IsAbs(dependency.Source.Path) {
+			filePath = filepath.Join(basePath, dependency.Source.Path)
+		}
 
 		remote, err := git.GetRemote(filePath)
 		if err == nil {

--- a/pkg/devspace/server/server.go
+++ b/pkg/devspace/server/server.go
@@ -39,7 +39,7 @@ type Server struct {
 const DefaultPort = 8090
 
 // NewServer creates a new server from the given parameters
-func NewServer(configLoader loader.ConfigLoader, config *latest.Config, generatedConfig *generated.Config, ignoreDownloadError bool, defaultContext, defaultNamespace string, forcePort *int, log log.Logger) (*Server, error) {
+func NewServer(configLoader loader.ConfigLoader, config *latest.Config, generatedConfig *generated.Config, host string, ignoreDownloadError bool, defaultContext, defaultNamespace string, forcePort *int, log log.Logger) (*Server, error) {
 	path, err := downloadUI()
 	if err != nil {
 		if !ignoreDownloadError {
@@ -54,13 +54,13 @@ func NewServer(configLoader loader.ConfigLoader, config *latest.Config, generate
 	if forcePort != nil {
 		usePort = *forcePort
 
-		unused, err := port.CheckHostPort("localhost", usePort)
+		unused, err := port.CheckHostPort(host, usePort)
 		if unused == false {
 			return nil, errors.Errorf("Port %d already in use: %v", usePort, err)
 		}
 	} else {
 		for i := 0; i < 20; i++ {
-			unused, err := port.CheckHostPort("localhost", usePort)
+			unused, err := port.CheckHostPort(host, usePort)
 			if unused {
 				break
 			}
@@ -80,7 +80,7 @@ func NewServer(configLoader loader.ConfigLoader, config *latest.Config, generate
 
 	return &Server{
 		Server: &http.Server{
-			Addr:    "localhost:" + strconv.Itoa(usePort),
+			Addr:    host + ":" + strconv.Itoa(usePort),
 			Handler: handler,
 			// ReadTimeout:  5 * time.Second,
 			// WriteTimeout: 10 * time.Second,

--- a/pkg/util/git/helper.go
+++ b/pkg/util/git/helper.go
@@ -4,12 +4,24 @@ import (
 	"github.com/pkg/errors"
 	"gopkg.in/src-d/go-git.v4"
 	"os"
+	"os/exec"
+	"strings"
 )
 
 // GetHash retrieves the current HEADs hash
 func GetHash(localPath string) (string, error) {
 	repo, err := git.PlainOpen(localPath)
 	if err != nil {
+		// last resort, try with cli
+		if isGitCommandAvailable() {
+			out, err := exec.Command("git", "rev-parse", "HEAD").CombinedOutput()
+			if err != nil {
+				return "", errors.Errorf("Error running 'git rev-parse HEAD': %v -> %s", err, string(out))
+			}
+
+			return strings.TrimSpace(string(out)), nil
+		}
+
 		return "", errors.Wrap(err, "git open")
 	}
 

--- a/pkg/util/port/port.go
+++ b/pkg/util/port/port.go
@@ -19,7 +19,7 @@ func CheckHostPort(host string, port int) (status bool, err error) {
 	}
 
 	// close the server
-	server.Close()
+	_ = server.Close()
 
 	// we successfully used and closed the port
 	// so it's now available to be used again


### PR DESCRIPTION
## Changes
- Adds a new flag `--port` to `devspace open` where the exact port can be specified (#1166)
- Adds a new flag `--host` to `devspace ui` where the hostname can be specified that devspace should listen on (#1163)
- Adds a new predefined variable DEVSPACE_PROFILE that contains the current selected profile (#1160)
- Fixes an issue where the wrong path was taken for DEVSPACE_GIT_COMMIT, when specified in a dependency (#1165)
- Update examples to v1beta9 & remove dscr.io references
