### PR TITLE
improvement(sync): add throttling to downstream change detection

### DIFF
--- a/cmd/dev.go
+++ b/cmd/dev.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"github.com/devspace-cloud/devspace/cmd/restore"
+	"github.com/devspace-cloud/devspace/cmd/save"
 	"github.com/devspace-cloud/devspace/pkg/devspace/plugin"
 	"github.com/devspace-cloud/devspace/pkg/devspace/upgrade"
 	"os"
@@ -62,6 +64,10 @@ type DevCmd struct {
 
 	Wait    bool
 	Timeout int
+
+	RestoreVars    bool
+	SaveVars       bool
+	VarsSecretName string
 
 	configLoader loader.ConfigLoader
 	log          log.Logger
@@ -130,6 +136,9 @@ Open terminal instead of logs:
 	devCmd.Flags().BoolVar(&cmd.Wait, "wait", false, "If true will wait first for pods to be running or fails after given timeout")
 	devCmd.Flags().IntVar(&cmd.Timeout, "timeout", 120, "Timeout until dev should stop waiting and fail")
 
+	devCmd.Flags().BoolVar(&cmd.RestoreVars, "restore-vars", false, "If true will restore the variables from kubernetes before loading the config")
+	devCmd.Flags().BoolVar(&cmd.SaveVars, "save-vars", false, "If true will save the variables to kubernetes after loading the config")
+	devCmd.Flags().StringVar(&cmd.VarsSecretName, "vars-secret", "devspace-vars", "The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled")
 	return devCmd
 }
 
@@ -188,10 +197,28 @@ func (cmd *DevCmd) Run(f factory.Factory, plugins []plugin.Metadata, cobraCmd *c
 		return err
 	}
 
+	// restore vars if wanted
+	if cmd.RestoreVars {
+		vars, _, err := restore.RestoreVarsFromSecret(client, cmd.VarsSecretName)
+		if err != nil {
+			return errors.Wrap(err, "restore vars")
+		}
+
+		generatedConfig.Vars = vars
+	}
+
 	// Get the config
 	config, err := cmd.loadConfig()
 	if err != nil {
 		return err
+	}
+
+	// save vars if wanted
+	if cmd.SaveVars {
+		err = save.SaveVarsInSecret(client, generatedConfig.Vars, cmd.VarsSecretName)
+		if err != nil {
+			return errors.Wrap(err, "save vars")
+		}
 	}
 
 	// Execute plugin hook

--- a/cmd/restore/restore.go
+++ b/cmd/restore/restore.go
@@ -1,0 +1,28 @@
+package restore
+
+import (
+	"github.com/devspace-cloud/devspace/cmd/flags"
+	"github.com/devspace-cloud/devspace/pkg/devspace/plugin"
+	"github.com/devspace-cloud/devspace/pkg/util/factory"
+	"github.com/spf13/cobra"
+)
+
+// NewRestoreCmd creates a new cobra command for the sub command
+func NewRestoreCmd(f factory.Factory, globalFlags *flags.GlobalFlags, plugins []plugin.Metadata) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "restore",
+		Short: "Restore configuration",
+		Long: `
+#######################################################
+################## devspace restore ###################
+#######################################################
+	`,
+		Args: cobra.NoArgs,
+	}
+
+	cmd.AddCommand(newVarsCmd(f, globalFlags))
+
+	// Add plugin commands
+	plugin.AddPluginCommands(cmd, plugins, "restore")
+	return cmd
+}

--- a/cmd/restore/vars.go
+++ b/cmd/restore/vars.go
@@ -1,0 +1,130 @@
+package restore
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/devspace-cloud/devspace/cmd/flags"
+	"github.com/devspace-cloud/devspace/cmd/save"
+	"github.com/devspace-cloud/devspace/pkg/devspace/kubectl"
+	"github.com/devspace-cloud/devspace/pkg/util/factory"
+	"github.com/devspace-cloud/devspace/pkg/util/message"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type varsCmd struct {
+	*flags.GlobalFlags
+
+	SecretName string
+}
+
+func newVarsCmd(f factory.Factory, globalFlags *flags.GlobalFlags) *cobra.Command {
+	cmd := &varsCmd{
+		GlobalFlags: globalFlags,
+	}
+
+	varsCmd := &cobra.Command{
+		Use:   "vars",
+		Short: "Restores variable values from kubernetes",
+		Long: `
+#######################################################
+############### devspace restore vars #################
+#######################################################
+Restores devspace config variable values from a kubernetes
+secret. 
+
+Examples:
+devspace restore vars
+devspace restore vars --namespace test 
+devspace restore vars --vars-secret my-secret
+#######################################################
+	`,
+		RunE: func(cobraCmd *cobra.Command, args []string) error {
+			return cmd.Run(f, cobraCmd, args)
+		}}
+
+	varsCmd.Flags().StringVar(&cmd.SecretName, "vars-secret", "devspace-vars", "The secret to restore the variables from")
+	return varsCmd
+}
+
+// RunSetVar executes the set var command logic
+func (cmd *varsCmd) Run(f factory.Factory, cobraCmd *cobra.Command, args []string) error {
+	// Set config root
+	logger := f.GetLog()
+	configLoader := f.NewConfigLoader(nil, logger)
+	configExists, err := configLoader.SetDevSpaceRoot()
+	if err != nil {
+		return err
+	}
+	if !configExists {
+		return errors.New(message.ConfigNotFound)
+	}
+
+	// Load generated config
+	generatedConfig, err := configLoader.Generated()
+	if err != nil {
+		return err
+	}
+
+	// Use last context if specified
+	err = cmd.UseLastContext(generatedConfig, logger)
+	if err != nil {
+		return err
+	}
+
+	// Get kubectl client
+	client, err := f.NewKubeClientFromContext(cmd.KubeContext, cmd.Namespace, cmd.SwitchContext)
+	if err != nil {
+		return errors.Wrap(err, "new kube client")
+	}
+
+	err = client.PrintWarning(generatedConfig, cmd.NoWarn, false, logger)
+	if err != nil {
+		return err
+	}
+
+	vars, restored, err := RestoreVarsFromSecret(client, cmd.SecretName)
+	if err != nil {
+		return err
+	} else if restored == false {
+		logger.Infof("No saved variables found in namespace %s", client.Namespace())
+		return nil
+	}
+
+	// exchange vars
+	generatedConfig.Vars = vars
+
+	// Make sure the vars are also saved to file
+	err = configLoader.SaveGenerated()
+	if err != nil {
+		return fmt.Errorf("error saving generated.yaml: %v", err)
+	}
+
+	logger.Donef("Successfully restored vars from secret %s/%s", client.Namespace(), cmd.SecretName)
+	return nil
+}
+
+// RestoreVarsFromSecret reads the previously saved vars from a secret in kubernetes
+func RestoreVarsFromSecret(client kubectl.Client, secretName string) (map[string]string, bool, error) {
+	secret, err := client.KubeClient().CoreV1().Secrets(client.Namespace()).Get(context.TODO(), secretName, metav1.GetOptions{})
+	if err != nil {
+		if kerrors.IsNotFound(err) == false {
+			return nil, false, err
+		}
+
+		return map[string]string{}, false, nil
+	} else if secret.Data == nil || len(secret.Data[save.SecretVarsKey]) == 0 {
+		return map[string]string{}, false, nil
+	}
+
+	vars := map[string]string{}
+	err = json.Unmarshal(secret.Data[save.SecretVarsKey], &vars)
+	if err != nil {
+		return nil, false, errors.Wrap(err, "unmarshal vars")
+	}
+
+	return vars, true, nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,6 +8,8 @@ import (
 	"github.com/devspace-cloud/devspace/cmd/list"
 	"github.com/devspace-cloud/devspace/cmd/remove"
 	"github.com/devspace-cloud/devspace/cmd/reset"
+	"github.com/devspace-cloud/devspace/cmd/restore"
+	"github.com/devspace-cloud/devspace/cmd/save"
 	"github.com/devspace-cloud/devspace/cmd/set"
 	"github.com/devspace-cloud/devspace/cmd/status"
 	"github.com/devspace-cloud/devspace/cmd/update"
@@ -129,6 +131,8 @@ func BuildRoot(f factory.Factory) *cobra.Command {
 	rootCmd.AddCommand(status.NewStatusCmd(f, plugins))
 	rootCmd.AddCommand(use.NewUseCmd(f, globalFlags, plugins))
 	rootCmd.AddCommand(update.NewUpdateCmd(f, globalFlags, plugins))
+	rootCmd.AddCommand(save.NewSaveCmd(f, globalFlags, plugins))
+	rootCmd.AddCommand(restore.NewRestoreCmd(f, globalFlags, plugins))
 
 	// Add main commands
 	rootCmd.AddCommand(NewInitCmd(f))

--- a/cmd/save/save.go
+++ b/cmd/save/save.go
@@ -1,0 +1,28 @@
+package save
+
+import (
+	"github.com/devspace-cloud/devspace/cmd/flags"
+	"github.com/devspace-cloud/devspace/pkg/devspace/plugin"
+	"github.com/devspace-cloud/devspace/pkg/util/factory"
+	"github.com/spf13/cobra"
+)
+
+// NewSaveCmd creates a new cobra command for the sub command
+func NewSaveCmd(f factory.Factory, globalFlags *flags.GlobalFlags, plugins []plugin.Metadata) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "save",
+		Short: "Save configuration",
+		Long: `
+#######################################################
+#################### devspace save ####################
+#######################################################
+	`,
+		Args: cobra.NoArgs,
+	}
+
+	cmd.AddCommand(newVarsCmd(f, globalFlags))
+
+	// Add plugin commands
+	plugin.AddPluginCommands(cmd, plugins, "save")
+	return cmd
+}

--- a/cmd/save/vars.go
+++ b/cmd/save/vars.go
@@ -1,0 +1,156 @@
+package save
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/devspace-cloud/devspace/cmd/flags"
+	"github.com/devspace-cloud/devspace/pkg/devspace/kubectl"
+	"github.com/devspace-cloud/devspace/pkg/util/factory"
+	"github.com/devspace-cloud/devspace/pkg/util/message"
+
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+type varsCmd struct {
+	*flags.GlobalFlags
+
+	SecretName string
+}
+
+const (
+	SecretVarsKey = "vars"
+)
+
+func newVarsCmd(f factory.Factory, globalFlags *flags.GlobalFlags) *cobra.Command {
+	cmd := &varsCmd{
+		GlobalFlags: globalFlags,
+	}
+
+	varsCmd := &cobra.Command{
+		Use:   "vars",
+		Short: "Saves variable values to kubernetes",
+		Long: `
+#######################################################
+################ devspace save vars ###################
+#######################################################
+Saves devspace config variable values into a kubernetes 
+secret. Variable values can be shared or restored via
+devspace restore vars.
+
+Examples:
+devspace save vars
+devspace save vars --namespace test 
+devspace save vars --vars-secret my-secret
+#######################################################
+	`,
+		RunE: func(cobraCmd *cobra.Command, args []string) error {
+			return cmd.Run(f, cobraCmd, args)
+		}}
+
+	varsCmd.Flags().StringVar(&cmd.SecretName, "vars-secret", "devspace-vars", "The secret to use to save the variables into")
+
+	return varsCmd
+}
+
+// RunSetVar executes the set var command logic
+func (cmd *varsCmd) Run(f factory.Factory, cobraCmd *cobra.Command, args []string) error {
+	// Set config root
+	logger := f.GetLog()
+	configLoader := f.NewConfigLoader(nil, logger)
+	configExists, err := configLoader.SetDevSpaceRoot()
+	if err != nil {
+		return err
+	}
+	if !configExists {
+		return errors.New(message.ConfigNotFound)
+	}
+
+	// Load generated config
+	generatedConfig, err := configLoader.Generated()
+	if err != nil {
+		return err
+	}
+
+	// Use last context if specified
+	err = cmd.UseLastContext(generatedConfig, logger)
+	if err != nil {
+		return err
+	}
+
+	// Get kubectl client
+	client, err := f.NewKubeClientFromContext(cmd.KubeContext, cmd.Namespace, cmd.SwitchContext)
+	if err != nil {
+		return errors.Wrap(err, "new kube client")
+	}
+
+	err = client.PrintWarning(generatedConfig, cmd.NoWarn, false, logger)
+	if err != nil {
+		return err
+	}
+
+	// Get config with adjusted cluster config
+	_, err = configLoader.Load()
+	if err != nil {
+		return err
+	}
+
+	// Make sure the vars are also saved to file
+	err = configLoader.SaveGenerated()
+	if err != nil {
+		return fmt.Errorf("error saving generated.yaml: %v", err)
+	}
+
+	// save the vars into the kubernetes secret
+	err = SaveVarsInSecret(client, generatedConfig.Vars, cmd.SecretName)
+	if err != nil {
+		return err
+	}
+
+	logger.Donef("Successfully written vars to secret %s/%s", client.Namespace(), cmd.SecretName)
+	return nil
+}
+
+// SaveVarsInSecret saves the given variables in the given secret with the kubernetes client
+func SaveVarsInSecret(client kubectl.Client, vars map[string]string, secretName string) error {
+	if vars == nil {
+		vars = map[string]string{}
+	}
+
+	// marshal vars
+	bytes, err := json.Marshal(vars)
+	if err != nil {
+		return err
+	}
+
+	secret, err := client.KubeClient().CoreV1().Secrets(client.Namespace()).Get(context.TODO(), secretName, metav1.GetOptions{})
+	if err != nil {
+		if kerrors.IsNotFound(err) == false {
+			return err
+		}
+
+		_, err = client.KubeClient().CoreV1().Secrets(client.Namespace()).Create(context.TODO(), &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: secretName,
+			},
+			Data: map[string][]byte{
+				SecretVarsKey: bytes,
+			},
+		}, metav1.CreateOptions{})
+		return err
+	}
+
+	if secret.Data == nil {
+		secret.Data = map[string][]byte{}
+	}
+
+	secret.Data[SecretVarsKey] = bytes
+	_, err = client.KubeClient().CoreV1().Secrets(client.Namespace()).Update(context.TODO(), secret, metav1.UpdateOptions{})
+	return err
+}

--- a/helper/cmd/sync/downstream.go
+++ b/helper/cmd/sync/downstream.go
@@ -9,6 +9,8 @@ import (
 // DownstreamCmd holds the downstream cmd flags
 type DownstreamCmd struct {
 	Exclude []string
+
+	Throttle int64
 }
 
 // NewDownstreamCmd creates a new downstream command
@@ -22,6 +24,7 @@ func NewDownstreamCmd() *cobra.Command {
 	}
 
 	downstreamCmd.Flags().StringSliceVar(&cmd.Exclude, "exclude", []string{}, "The exclude paths for downstream watching")
+	downstreamCmd.Flags().Int64Var(&cmd.Throttle, "throttle", 5, "The amount of milliseconds to throttle change detection per 100 files")
 	return downstreamCmd
 }
 
@@ -36,6 +39,7 @@ func (cmd *DownstreamCmd) Run(cobraCmd *cobra.Command, args []string) error {
 		RemotePath:   absolutePath,
 		ExcludePaths: cmd.Exclude,
 
+		Throttle:    cmd.Throttle,
 		ExitOnClose: true,
 	})
 }

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -487,6 +487,9 @@ type SyncConfig struct {
 	WaitInitialSync *bool            `yaml:"waitInitialSync,omitempty"`
 	BandwidthLimits *BandwidthLimits `yaml:"bandwidthLimits,omitempty"`
 
+	// If greater zero, describes the amount of milliseconds to wait after each checked 100 files
+	ThrottleChangeDetection *int64 `yaml:"throttleChangeDetection,omitempty"`
+
 	OnUpload   *SyncOnUpload   `yaml:"onUpload,omitempty"`
 	OnDownload *SyncOnDownload `yaml:"onDownload,omitempty"`
 }

--- a/pkg/devspace/configure/image.go
+++ b/pkg/devspace/configure/image.go
@@ -18,6 +18,7 @@ import (
 )
 
 const dockerHubHostname = "hub.docker.com"
+const githubDockerRegistry = "docker.pkg.github.com"
 const noRegistryImage = "devspace"
 
 // newImageConfigFromImageName returns an image config based on the image
@@ -218,6 +219,7 @@ func (m *manager) getRegistryURL(dockerClient docker.Client) (string, error) {
 	var (
 		useDockerHub          = "Use " + dockerHubHostname
 		skipImagePush         = "Always skip image push (advanced, config will not work with remote clusters)"
+		useGithubRegistry     = "Use github docker registry"
 		useOtherRegistry      = "Use other registry"
 		registryUsernameHint  = " => you are logged in as %s"
 		registryDefaultOption = useDockerHub
@@ -230,7 +232,7 @@ func (m *manager) getRegistryURL(dockerClient docker.Client) (string, error) {
 		registryDefaultOption = useDockerHub
 	}
 
-	registryOptions := []string{useDockerHub, useOtherRegistry}
+	registryOptions := []string{useDockerHub, useGithubRegistry, useOtherRegistry}
 	registryOptions = append(registryOptions, skipImagePush)
 	selectedRegistry, err := m.log.Question(&survey.QuestionOptions{
 		Question:     "Which registry do you want to use for storing your Docker images?",
@@ -246,6 +248,9 @@ func (m *manager) getRegistryURL(dockerClient docker.Client) (string, error) {
 		return "", nil
 	} else if selectedRegistry == useDockerHub {
 		registryURL = dockerHubHostname
+	} else if selectedRegistry == useGithubRegistry {
+		registryURL = githubDockerRegistry
+		registryLoginHint = fmt.Sprintf(registryLoginHint, " "+registryURL)
 	} else {
 		registryURL, err = m.log.Question(&survey.QuestionOptions{
 			Question:     "Please enter the registry URL without image name:",

--- a/pkg/devspace/services/sync.go
+++ b/pkg/devspace/services/sync.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -369,6 +370,9 @@ func (serviceClient *client) startSync(pod *v1.Pod, container string, syncConfig
 
 	// Start downstream
 	downstreamArgs := []string{DevSpaceHelperContainerPath, "sync", "downstream"}
+	if syncConfig.ThrottleChangeDetection != nil {
+		downstreamArgs = append(downstreamArgs, "--throttle", strconv.FormatInt(*syncConfig.ThrottleChangeDetection, 10))
+	}
 	for _, exclude := range options.ExcludePaths {
 		downstreamArgs = append(downstreamArgs, "--exclude", exclude)
 	}


### PR DESCRIPTION
### Changes
- Throttle change detection in downstream sync
- Add an option `dev.sync. throttleChangeDetection` to configure throttling of downstream change detection
- Adds `devspace save vars` and `devspace restore vars` that save or restore devspace config variables from kubernetes secrets
- Adds `--save-vars` and `--restore-vars` as flags to `devspace dev` and `devspace deploy`
- Adds new github docker registry option to `devspace init`