### PR TITLE
initialCompareBy, devspace restart & --print-sync

### DIFF
--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -1,0 +1,151 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/devspace-cloud/devspace/pkg/devspace/plugin"
+	"github.com/devspace-cloud/devspace/pkg/devspace/services"
+	"github.com/devspace-cloud/devspace/pkg/devspace/services/targetselector"
+	"github.com/devspace-cloud/devspace/pkg/util/factory"
+
+	"github.com/devspace-cloud/devspace/cmd/flags"
+	"github.com/devspace-cloud/devspace/pkg/util/log"
+	"github.com/devspace-cloud/devspace/pkg/util/message"
+	"github.com/pkg/errors"
+
+	"github.com/spf13/cobra"
+)
+
+// RestartCmd holds the required data for the cmd
+type RestartCmd struct {
+	*flags.GlobalFlags
+
+	log log.Logger
+}
+
+// NewRestartCmd creates a new purge command
+func NewRestartCmd(f factory.Factory, globalFlags *flags.GlobalFlags, plugins []plugin.Metadata) *cobra.Command {
+	cmd := &RestartCmd{
+		GlobalFlags: globalFlags,
+		log:         log.GetInstance(),
+	}
+
+	restartCmd := &cobra.Command{
+		Use:   "restart",
+		Short: "Restarts containers where the sync restart helper is injected",
+		Long: `
+#######################################################
+################## devspace restart ###################
+#######################################################
+Restarts containers where the sync restart helper
+is injected:
+
+devspace restart
+devspace restart -n my-namespace
+#######################################################`,
+		Args: cobra.NoArgs,
+		RunE: func(cobraCmd *cobra.Command, args []string) error {
+			return cmd.Run(f, plugins, cobraCmd, args)
+		},
+	}
+
+	return restartCmd
+}
+
+// Run executes the purge command logic
+func (cmd *RestartCmd) Run(f factory.Factory, plugins []plugin.Metadata, cobraCmd *cobra.Command, args []string) error {
+	// Set config root
+	cmd.log = f.GetLog()
+	configOptions := cmd.ToConfigOptions()
+	configLoader := f.NewConfigLoader(configOptions, cmd.log)
+	configExists, err := configLoader.SetDevSpaceRoot()
+	if err != nil {
+		return err
+	} else if !configExists {
+		return errors.New(message.ConfigNotFound)
+	}
+
+	log.StartFileLogging()
+
+	// Get config with adjusted cluster config
+	generatedConfig, err := configLoader.Generated()
+	if err != nil {
+		return err
+	}
+
+	// Use last context if specified
+	err = cmd.UseLastContext(generatedConfig, cmd.log)
+	if err != nil {
+		return err
+	}
+
+	client, err := f.NewKubeClientFromContext(cmd.KubeContext, cmd.Namespace, cmd.SwitchContext)
+	if err != nil {
+		return errors.Wrap(err, "create kube client")
+	}
+
+	err = client.PrintWarning(generatedConfig, cmd.NoWarn, false, cmd.log)
+	if err != nil {
+		return err
+	}
+
+	// Execute plugin hook
+	err = plugin.ExecutePluginHook(plugins, "restart", cmd.KubeContext, cmd.Namespace)
+	if err != nil {
+		return err
+	}
+
+	// Get config with adjusted cluster config
+	config, err := configLoader.Load()
+	if err != nil {
+		return err
+	}
+
+	// restart containers
+	restarts := 0
+	if config.Dev != nil {
+		for _, syncPath := range config.Dev.Sync {
+			if syncPath.OnUpload == nil || !syncPath.OnUpload.RestartContainer {
+				continue
+			}
+
+			selector, err := targetselector.NewTargetSelector(config, client, &targetselector.SelectorParameter{
+				CmdParameter: targetselector.CmdParameter{
+					Namespace: cmd.Namespace,
+				},
+				ConfigParameter: targetselector.ConfigParameter{
+					LabelSelector: syncPath.LabelSelector,
+					Namespace:     syncPath.Namespace,
+					ContainerName: syncPath.ContainerName,
+				},
+			}, true, targetselector.ImageSelectorFromConfig(syncPath.ImageName, config, generatedConfig))
+			if err != nil {
+				return errors.Errorf("Error creating target selector: %v", err)
+			}
+
+			cmd.log.StartWait("Restart: Waiting for pods...")
+			pod, container, err := selector.GetContainer(false, cmd.log)
+			cmd.log.StopWait()
+			if err != nil {
+				return errors.Errorf("Error selecting pod: %v", err)
+			}
+
+			stdOut, stdErr, err := client.ExecBuffered(pod, container.Name, []string{services.DevSpaceHelperContainerPath, "restart"}, nil)
+			if err != nil {
+				return fmt.Errorf("error restarting container %s in pod %s/%s: %s %s => %v", container.Name, pod.Namespace, pod.Name, string(stdOut), string(stdErr), err)
+			}
+
+			cmd.log.Donef("Successfully restarted container %s in pod %s/%s", container.Name, pod.Namespace, pod.Name)
+			restarts++
+		}
+	}
+
+	err = configLoader.SaveGenerated()
+	if err != nil {
+		cmd.log.Errorf("Error saving generated.yaml: %v", err)
+	}
+
+	if restarts == 0 {
+		cmd.log.Warn("No containers to restart found, please make sure you have set `dev.sync[*].onUpload.restartContainer` to `true` somewhere in your sync path")
+	}
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -136,6 +136,7 @@ func BuildRoot(f factory.Factory) *cobra.Command {
 
 	// Add main commands
 	rootCmd.AddCommand(NewInitCmd(f))
+	rootCmd.AddCommand(NewRestartCmd(f, globalFlags, plugins))
 	rootCmd.AddCommand(NewDevCmd(f, globalFlags, plugins))
 	rootCmd.AddCommand(NewBuildCmd(f, globalFlags, plugins))
 	rootCmd.AddCommand(NewSyncCmd(f, globalFlags, plugins))

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -109,6 +109,8 @@ func (cmd *SyncCmd) Run(f factory.Factory, plugins []plugin.Metadata, cobraCmd *
 		if err != nil {
 			return err
 		}
+	} else {
+		logger.Warnf("You are using `devspace sync` without a devspace.yaml, use the flag `--config` to specify a config")
 	}
 
 	// Use last context if specified

--- a/e2e/tests/dev/dev.go
+++ b/e2e/tests/dev/dev.go
@@ -51,8 +51,8 @@ func (s *fakeServiceClient) StartPortForwarding(interrupt chan error) error {
 	return err
 }
 
-func (s *fakeServiceClient) StartSync(interrupt chan error, verboseSync bool) error {
-	err := s.Client.StartSync(s.factory.interruptSync, verboseSync)
+func (s *fakeServiceClient) StartSync(interrupt chan error, printSync, verboseSync bool) error {
+	err := s.Client.StartSync(s.factory.interruptSync, printSync, verboseSync)
 	return err
 }
 

--- a/e2e/tests/run/run.go
+++ b/e2e/tests/run/run.go
@@ -47,8 +47,8 @@ func (s *fakeServiceClient) StartSyncFromCmd(syncConfig *latest.SyncConfig, inte
 	return err
 }
 
-func (s *fakeServiceClient) StartSync(interrupt chan error, verboseSync bool) error {
-	err := s.Client.StartSync(s.factory.interrupt, verboseSync)
+func (s *fakeServiceClient) StartSync(interrupt chan error, printSync, verboseSync bool) error {
+	err := s.Client.StartSync(s.factory.interrupt, printSync, verboseSync)
 	return err
 }
 

--- a/e2e/tests/sync/sync.go
+++ b/e2e/tests/sync/sync.go
@@ -47,8 +47,8 @@ func (s *fakeServiceClient) StartSyncFromCmd(syncConfig *latest.SyncConfig, inte
 	return err
 }
 
-func (s *fakeServiceClient) StartSync(interrupt chan error, verboseSync bool) error {
-	err := s.Client.StartSync(s.factory.interrupt, verboseSync)
+func (s *fakeServiceClient) StartSync(interrupt chan error, printSync, verboseSync bool) error {
+	err := s.Client.StartSync(s.factory.interrupt, printSync, verboseSync)
 	return err
 }
 

--- a/helper/cmd/restart.go
+++ b/helper/cmd/restart.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"github.com/devspace-cloud/devspace/helper/util"
+	"github.com/spf13/cobra"
+)
+
+// RestartCmd holds the cmd flags
+type RestartCmd struct{}
+
+// NewRestartCmd creates a new restart command
+func NewRestartCmd() *cobra.Command {
+	cmd := &RestartCmd{}
+	restartCmd := &cobra.Command{
+		Use:   "restart",
+		Short: "Restarts the container if the restart helper is present",
+		Args:  cobra.NoArgs,
+		RunE:  cmd.Run,
+	}
+
+	return restartCmd
+}
+
+// Run runs the command logic
+func (cmd *RestartCmd) Run(cobraCmd *cobra.Command, args []string) error {
+	return util.NewContainerRestarter().RestartContainer()
+}

--- a/helper/cmd/root.go
+++ b/helper/cmd/root.go
@@ -33,6 +33,7 @@ func Execute() {
 func BuildRoot() *cobra.Command {
 	rootCmd := NewRootCmd()
 
+	rootCmd.AddCommand(NewRestartCmd())
 	rootCmd.AddCommand(NewVersionCmd())
 	rootCmd.AddCommand(NewTunnelCmd())
 	rootCmd.AddCommand(sync.NewSyncCmd())

--- a/helper/cmd/tunnel.go
+++ b/helper/cmd/tunnel.go
@@ -9,7 +9,7 @@ import (
 // TunnelCmd holds the tunnel cmd flags
 type TunnelCmd struct{}
 
-// NewTunnelCmd creates a new downstream command
+// NewTunnelCmd creates a new tunnel command
 func NewTunnelCmd() *cobra.Command {
 	cmd := &TunnelCmd{}
 	tunnelCmd := &cobra.Command{

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -470,16 +470,17 @@ type OpenConfig struct {
 
 // SyncConfig defines the paths for a SyncFolder
 type SyncConfig struct {
-	ImageName            string              `yaml:"imageName,omitempty"`
-	LabelSelector        map[string]string   `yaml:"labelSelector,omitempty"`
-	ContainerName        string              `yaml:"containerName,omitempty"`
-	Namespace            string              `yaml:"namespace,omitempty"`
-	LocalSubPath         string              `yaml:"localSubPath,omitempty"`
-	ContainerPath        string              `yaml:"containerPath,omitempty"`
-	ExcludePaths         []string            `yaml:"excludePaths,omitempty"`
-	DownloadExcludePaths []string            `yaml:"downloadExcludePaths,omitempty"`
-	UploadExcludePaths   []string            `yaml:"uploadExcludePaths,omitempty"`
-	InitialSync          InitialSyncStrategy `yaml:"initialSync,omitempty"`
+	ImageName            string               `yaml:"imageName,omitempty"`
+	LabelSelector        map[string]string    `yaml:"labelSelector,omitempty"`
+	ContainerName        string               `yaml:"containerName,omitempty"`
+	Namespace            string               `yaml:"namespace,omitempty"`
+	LocalSubPath         string               `yaml:"localSubPath,omitempty"`
+	ContainerPath        string               `yaml:"containerPath,omitempty"`
+	ExcludePaths         []string             `yaml:"excludePaths,omitempty"`
+	DownloadExcludePaths []string             `yaml:"downloadExcludePaths,omitempty"`
+	UploadExcludePaths   []string             `yaml:"uploadExcludePaths,omitempty"`
+	InitialSync          InitialSyncStrategy  `yaml:"initialSync,omitempty"`
+	InitialSyncCompareBy InitialSyncCompareBy `yaml:"initialSyncCompareBy,omitempty"`
 
 	DisableDownload *bool `yaml:"disableDownload,omitempty"`
 	DisableUpload   *bool `yaml:"disableUpload,omitempty"`
@@ -547,6 +548,15 @@ const (
 	InitialSyncStrategyPreferRemote InitialSyncStrategy = "preferRemote"
 	InitialSyncStrategyPreferNewest InitialSyncStrategy = "preferNewest"
 	InitialSyncStrategyKeepAll      InitialSyncStrategy = "keepAll"
+)
+
+// InitialSyncCompareBy is the type of how a change should be determined during the initial sync
+type InitialSyncCompareBy string
+
+// List of values that compare by can take
+const (
+	InitialSyncCompareByMTime InitialSyncCompareBy = "mtime"
+	InitialSyncCompareBySize  InitialSyncCompareBy = "size"
 )
 
 // BandwidthLimits defines the struct for specifying the sync bandwidth limits

--- a/pkg/devspace/kubectl/logs.go
+++ b/pkg/devspace/kubectl/logs.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/devspace-cloud/devspace/pkg/util/log"
+	logpkg "github.com/devspace-cloud/devspace/pkg/util/log"
 	"github.com/devspace-cloud/devspace/pkg/util/ptr"
 	"github.com/mgutz/ansi"
 
@@ -40,18 +40,8 @@ type logLine struct {
 	color string
 }
 
-var colors = []string{
-	"blue",
-	"green",
-	"yellow",
-	"magenta",
-	"cyan",
-	"red",
-	"white+b",
-}
-
 // LogMultipleTimeout will log multiple and wait for a specific time for ready pods until timeout
-func (client *client) LogMultipleTimeout(imageSelector []string, interrupt chan error, tail *int64, writer io.Writer, timeout time.Duration, log log.Logger) error {
+func (client *client) LogMultipleTimeout(imageSelector []string, interrupt chan error, tail *int64, writer io.Writer, timeout time.Duration, log logpkg.Logger) error {
 	// Get pods
 	log.StartWait("Find running pods...")
 	pods, err := client.GetRunningPodsWithImage(imageSelector, client.namespace, timeout)
@@ -112,7 +102,7 @@ func (client *client) LogMultipleTimeout(imageSelector []string, interrupt chan 
 						}
 
 						wg.Done()
-					}(prefix, reader, colors[idx%len(colors)])
+					}(prefix, reader, logpkg.Colors[idx%len(logpkg.Colors)])
 					break Outer
 				}
 			}
@@ -138,7 +128,7 @@ func (client *client) LogMultipleTimeout(imageSelector []string, interrupt chan 
 }
 
 // LogMultiple will log multiple
-func (client *client) LogMultiple(imageSelector []string, interrupt chan error, tail *int64, writer io.Writer, log log.Logger) error {
+func (client *client) LogMultiple(imageSelector []string, interrupt chan error, tail *int64, writer io.Writer, log logpkg.Logger) error {
 	return client.LogMultipleTimeout(imageSelector, interrupt, tail, writer, time.Minute*2, log)
 }
 

--- a/pkg/devspace/services/client.go
+++ b/pkg/devspace/services/client.go
@@ -21,7 +21,7 @@ type Client interface {
 	StartReversePortForwarding(interrupt chan error) error
 
 	StartSyncFromCmd(syncConfig *latest.SyncConfig, interrupt chan error, verbose bool) error
-	StartSync(interrupt chan error, verboseSync bool) error
+	StartSync(interrupt chan error, printSyncLog bool, verboseSync bool) error
 
 	StartTerminal(args []string, imageSelector []string, interrupt chan error, wait bool) (int, error)
 }

--- a/pkg/devspace/services/sync.go
+++ b/pkg/devspace/services/sync.go
@@ -258,14 +258,20 @@ func (serviceClient *client) startSync(pod *v1.Pod, container string, syncConfig
 		downstreamDisabled = *syncConfig.DisableDownload
 	}
 
+	compareBy := latest.InitialSyncCompareByMTime
+	if syncConfig.InitialSyncCompareBy != "" {
+		compareBy = syncConfig.InitialSyncCompareBy
+	}
+
 	options := sync.Options{
-		Verbose:            verbose,
-		SyncError:          make(chan error),
-		SyncDone:           syncDone,
-		InitialSync:        syncConfig.InitialSync,
-		UpstreamDisabled:   upstreamDisabled,
-		DownstreamDisabled: downstreamDisabled,
-		Log:                customLog,
+		Verbose:              verbose,
+		SyncError:            make(chan error),
+		SyncDone:             syncDone,
+		InitialSyncCompareBy: compareBy,
+		InitialSync:          syncConfig.InitialSync,
+		UpstreamDisabled:     upstreamDisabled,
+		DownstreamDisabled:   downstreamDisabled,
+		Log:                  customLog,
 	}
 
 	// Add onDownload hooks

--- a/pkg/devspace/services/sync.go
+++ b/pkg/devspace/services/sync.go
@@ -75,14 +75,14 @@ func (serviceClient *client) StartSyncFromCmd(syncConfig *latest.SyncConfig, int
 }
 
 // StartSync starts the syncing functionality
-func (serviceClient *client) StartSync(interrupt chan error, verboseSync bool) error {
+func (serviceClient *client) StartSync(interrupt chan error, printSyncLog bool, verboseSync bool) error {
 	if serviceClient.config.Dev == nil {
 		return nil
 	}
 
 	// Start sync client
-	for _, syncConfig := range serviceClient.config.Dev.Sync {
-		err := serviceClient.startSyncClient(&startClientOptions{
+	for idx, syncConfig := range serviceClient.config.Dev.Sync {
+		options := &startClientOptions{
 			Interrupt: interrupt,
 
 			SyncConfig: syncConfig,
@@ -99,7 +99,16 @@ func (serviceClient *client) StartSync(interrupt chan error, verboseSync bool) e
 
 			AllowPodPick: false,
 			Verbose:      verboseSync,
-		}, serviceClient.log)
+		}
+
+		// should we print the logs?
+		if printSyncLog {
+			logger := logpkg.NewPrefixLogger(fmt.Sprintf("[Sync - %d] ", idx), logpkg.Colors[idx%len(logpkg.Colors)], serviceClient.log)
+			options.SyncLog = logger
+			options.RestartLog = logger
+		}
+
+		err := serviceClient.startSyncClient(options, serviceClient.log)
 		if err != nil {
 			return errors.Errorf("Unable to start sync: %v", err)
 		}

--- a/pkg/devspace/sync/initial.go
+++ b/pkg/devspace/sync/initial.go
@@ -21,7 +21,8 @@ type initialSyncer struct {
 type initialSyncOptions struct {
 	LocalPath string
 
-	Strategy latest.InitialSyncStrategy
+	CompareBy latest.InitialSyncCompareBy
+	Strategy  latest.InitialSyncStrategy
 
 	IgnoreMatcher         gitignore.IgnoreParser
 	DownloadIgnoreMatcher gitignore.IgnoreParser
@@ -359,8 +360,12 @@ func (i *initialSyncer) decide(fileInformation *FileInformation, strategy latest
 		}
 
 		// File did not change or was changed by downstream
-		if fileInformation.Mtime == i.o.FileIndex.fileMap[fileInformation.Name].Mtime && fileInformation.Size == i.o.FileIndex.fileMap[fileInformation.Name].Size {
-			return noAction
+		if fileInformation.Size == i.o.FileIndex.fileMap[fileInformation.Name].Size {
+			if fileInformation.Mtime == i.o.FileIndex.fileMap[fileInformation.Name].Mtime {
+				return noAction
+			} else if i.o.CompareBy == latest.InitialSyncCompareBySize {
+				return noAction
+			}
 		}
 
 		// Okay we have a conflict so now we decide based on the given strategy

--- a/pkg/devspace/sync/sync.go
+++ b/pkg/devspace/sync/sync.go
@@ -46,7 +46,8 @@ type Options struct {
 	UpstreamDisabled   bool
 	DownstreamDisabled bool
 
-	InitialSync latest.InitialSyncStrategy
+	InitialSyncCompareBy latest.InitialSyncCompareBy
+	InitialSync          latest.InitialSyncStrategy
 
 	// These channels can be used to listen for certain sync events
 	DownstreamInitialSyncDone chan bool
@@ -272,6 +273,7 @@ func (s *Sync) initialSync() error {
 	initialSync := newInitialSyncer(&initialSyncOptions{
 		LocalPath: s.LocalPath,
 		Strategy:  s.Options.InitialSync,
+		CompareBy: s.Options.InitialSyncCompareBy,
 
 		IgnoreMatcher:         s.ignoreMatcher,
 		DownloadIgnoreMatcher: s.downloadIgnoreMatcher,

--- a/pkg/util/log/prefix_logger.go
+++ b/pkg/util/log/prefix_logger.go
@@ -1,0 +1,193 @@
+package log
+
+import (
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/mgutz/ansi"
+	"github.com/sirupsen/logrus"
+)
+
+var Colors = []string{
+	"blue",
+	"green",
+	"yellow",
+	"magenta",
+	"cyan",
+	"red",
+	"white+b",
+}
+
+func NewPrefixLogger(prefix string, color string, base Logger) Logger {
+	return &prefixLogger{
+		Logger: base,
+
+		color:  color,
+		prefix: prefix,
+	}
+}
+
+type prefixLogger struct {
+	Logger
+
+	prefix   string
+	color    string
+	logMutex sync.Mutex
+}
+
+func (s *prefixLogger) writeMessage(message string) {
+	s.WriteString(ansi.Color(s.prefix, s.color) + message)
+}
+
+func (s *prefixLogger) Debug(args ...interface{}) {
+	s.logMutex.Lock()
+	defer s.logMutex.Unlock()
+
+	s.writeMessage(fmt.Sprintln(args...))
+}
+
+func (s *prefixLogger) Debugf(format string, args ...interface{}) {
+	s.logMutex.Lock()
+	defer s.logMutex.Unlock()
+
+	s.writeMessage(fmt.Sprintf(format, args...) + "\n")
+}
+
+func (s *prefixLogger) Info(args ...interface{}) {
+	s.logMutex.Lock()
+	defer s.logMutex.Unlock()
+
+	s.writeMessage(fmt.Sprintln(args...))
+}
+
+func (s *prefixLogger) Infof(format string, args ...interface{}) {
+	s.logMutex.Lock()
+	defer s.logMutex.Unlock()
+
+	s.writeMessage(fmt.Sprintf(format, args...) + "\n")
+}
+
+func (s *prefixLogger) Warn(args ...interface{}) {
+	s.logMutex.Lock()
+	defer s.logMutex.Unlock()
+
+	s.writeMessage("Warning: " + fmt.Sprintln(args...))
+}
+
+func (s *prefixLogger) Warnf(format string, args ...interface{}) {
+	s.logMutex.Lock()
+	defer s.logMutex.Unlock()
+
+	s.writeMessage("Warning: " + fmt.Sprintf(format, args...) + "\n")
+}
+
+func (s *prefixLogger) Error(args ...interface{}) {
+	s.logMutex.Lock()
+	defer s.logMutex.Unlock()
+
+	s.writeMessage("Error: " + fmt.Sprintln(args...))
+}
+
+func (s *prefixLogger) Errorf(format string, args ...interface{}) {
+	s.logMutex.Lock()
+	defer s.logMutex.Unlock()
+
+	s.writeMessage("Error: " + fmt.Sprintf(format, args...) + "\n")
+}
+
+func (s *prefixLogger) Fatal(args ...interface{}) {
+	s.logMutex.Lock()
+	defer s.logMutex.Unlock()
+
+	msg := fmt.Sprintln(args...)
+	s.writeMessage("Fatal: " + msg)
+	os.Exit(1)
+}
+
+func (s *prefixLogger) Fatalf(format string, args ...interface{}) {
+	s.logMutex.Lock()
+	defer s.logMutex.Unlock()
+
+	msg := fmt.Sprintf(format, args...)
+	s.writeMessage("Fatal: " + msg + "\n")
+	os.Exit(1)
+}
+
+func (s *prefixLogger) Panic(args ...interface{}) {
+	s.logMutex.Lock()
+	defer s.logMutex.Unlock()
+
+	s.writeMessage("Panic: " + fmt.Sprintln(args...))
+	panic(fmt.Sprintln(args...))
+}
+
+func (s *prefixLogger) Panicf(format string, args ...interface{}) {
+	s.logMutex.Lock()
+	defer s.logMutex.Unlock()
+
+	s.writeMessage("Panic: " + fmt.Sprintf(format, args...) + "\n")
+	panic(fmt.Sprintf(format, args...))
+}
+
+func (s *prefixLogger) Done(args ...interface{}) {
+	s.logMutex.Lock()
+	defer s.logMutex.Unlock()
+
+	s.writeMessage(fmt.Sprintln(args...))
+}
+
+func (s *prefixLogger) Donef(format string, args ...interface{}) {
+	s.logMutex.Lock()
+	defer s.logMutex.Unlock()
+
+	s.writeMessage(fmt.Sprintf(format, args...) + "\n")
+}
+
+func (s *prefixLogger) Fail(args ...interface{}) {
+	s.logMutex.Lock()
+	defer s.logMutex.Unlock()
+
+	s.writeMessage(fmt.Sprintln(args...))
+}
+
+func (s *prefixLogger) Failf(format string, args ...interface{}) {
+	s.logMutex.Lock()
+	defer s.logMutex.Unlock()
+
+	s.writeMessage(fmt.Sprintf(format, args...) + "\n")
+}
+
+func (s *prefixLogger) Print(level logrus.Level, args ...interface{}) {
+	switch level {
+	case logrus.InfoLevel:
+		s.Info(args...)
+	case logrus.DebugLevel:
+		s.Debug(args...)
+	case logrus.WarnLevel:
+		s.Warn(args...)
+	case logrus.ErrorLevel:
+		s.Error(args...)
+	case logrus.PanicLevel:
+		s.Panic(args...)
+	case logrus.FatalLevel:
+		s.Fatal(args...)
+	}
+}
+
+func (s *prefixLogger) Printf(level logrus.Level, format string, args ...interface{}) {
+	switch level {
+	case logrus.InfoLevel:
+		s.Infof(format, args...)
+	case logrus.DebugLevel:
+		s.Debugf(format, args...)
+	case logrus.WarnLevel:
+		s.Warnf(format, args...)
+	case logrus.ErrorLevel:
+		s.Errorf(format, args...)
+	case logrus.PanicLevel:
+		s.Panicf(format, args...)
+	case logrus.FatalLevel:
+		s.Fatalf(format, args...)
+	}
+}


### PR DESCRIPTION
### Changes
- Adds a new config option `dev.sync.initialCompareBy` that allows you to specify that a file should only be synced if file size has changed (#1177)
- Adds a new command `devspace restart` that triggers a restart for a container if `dev.sync.onUpload.restartContainer` was specified (#1161)
- Adds a new flag `--print-sync` to `devspace dev` that prints the sync output to the console (#1111)