### PR TITLE
multiple profile parents & profile sources

### DIFF
--- a/cmd/flags/flags.go
+++ b/cmd/flags/flags.go
@@ -15,11 +15,12 @@ type GlobalFlags struct {
 	NoWarn bool
 	Debug  bool
 
-	Namespace   string
-	KubeContext string
-	Profile     string
-	ConfigPath  string
-	Vars        []string
+	Namespace      string
+	KubeContext    string
+	Profile        string
+	ProfileRefresh bool
+	ConfigPath     string
+	Vars           []string
 
 	SwitchContext bool
 
@@ -47,11 +48,12 @@ func (gf *GlobalFlags) UseLastContext(generatedConfig *generated.Config, log log
 // ToConfigOptions converts the globalFlags into config options
 func (gf *GlobalFlags) ToConfigOptions() *loader.ConfigOptions {
 	return &loader.ConfigOptions{
-		Profile:     gf.Profile,
-		ConfigPath:  gf.ConfigPath,
-		KubeContext: gf.KubeContext,
-		Namespace:   gf.Namespace,
-		Vars:        gf.Vars,
+		Profile:        gf.Profile,
+		ProfileRefresh: gf.ProfileRefresh,
+		ConfigPath:     gf.ConfigPath,
+		KubeContext:    gf.KubeContext,
+		Namespace:      gf.Namespace,
+		Vars:           gf.Vars,
 	}
 }
 
@@ -68,6 +70,7 @@ func SetGlobalFlags(flags *flag.FlagSet) *GlobalFlags {
 
 	flags.StringVar(&globalFlags.ConfigPath, "config", "", "The devspace config file to use")
 	flags.StringVarP(&globalFlags.Profile, "profile", "p", "", "The devspace profile to use (if there is any)")
+	flags.BoolVar(&globalFlags.ProfileRefresh, "profile-refresh", false, "If true will pull and re-download profile parent sources")
 	flags.StringVarP(&globalFlags.Namespace, "namespace", "n", "", "The kubernetes namespace to use")
 	flags.StringVar(&globalFlags.KubeContext, "kube-context", "", "The kubernetes context to use")
 	flags.BoolVarP(&globalFlags.SwitchContext, "switch-context", "s", false, "Switches and uses the last kube context and namespace that was used to deploy the DevSpace project")

--- a/cmd/reset/dependencies.go
+++ b/cmd/reset/dependencies.go
@@ -1,9 +1,9 @@
 package reset
 
 import (
+	dependencyutil "github.com/devspace-cloud/devspace/pkg/devspace/dependency/util"
 	"os"
 
-	"github.com/devspace-cloud/devspace/pkg/devspace/dependency"
 	"github.com/devspace-cloud/devspace/pkg/util/factory"
 
 	"github.com/pkg/errors"
@@ -40,9 +40,9 @@ devspace reset dependencies
 // RunResetDependencies executes the reset dependencies command logic
 func (cmd *dependenciesCmd) RunResetDependencies(f factory.Factory, cobraCmd *cobra.Command, args []string) error {
 	log := f.GetLog()
-	err := os.RemoveAll(dependency.DependencyFolderPath)
+	err := os.RemoveAll(dependencyutil.DependencyFolderPath)
 	if err != nil {
-		return errors.Wrapf(err, "delete %s", dependency.DependencyFolderPath)
+		return errors.Wrapf(err, "delete %s", dependencyutil.DependencyFolderPath)
 	}
 
 	log.Done("Successfully reseted the dependency cache")

--- a/pkg/devspace/config/loader/get.go
+++ b/pkg/devspace/config/loader/get.go
@@ -131,6 +131,8 @@ type ConfigOptions struct {
 	BasePath string
 	// The profile that should be loaded
 	Profile string
+	// If the profile parents that are loaded from other sources should be refreshed
+	ProfileRefresh bool
 
 	GeneratedConfig *generated.Config
 	LoadedVars      map[string]string

--- a/pkg/devspace/config/loader/parse.go
+++ b/pkg/devspace/config/loader/parse.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -99,7 +100,7 @@ func (l *configLoader) ParseCommands() ([]*latest.CommandConfig, error) {
 // parseConfig fills the variables in the data and parses the config
 func (l *configLoader) parseConfig(data map[interface{}]interface{}) (*latest.Config, error) {
 	// Get profile
-	profiles, err := versions.ParseProfile(data, l.options.Profile)
+	profiles, err := versions.ParseProfile(filepath.Dir(l.ConfigPath()), data, l.options.Profile, l.log)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/devspace/config/loader/parse.go
+++ b/pkg/devspace/config/loader/parse.go
@@ -100,7 +100,7 @@ func (l *configLoader) ParseCommands() ([]*latest.CommandConfig, error) {
 // parseConfig fills the variables in the data and parses the config
 func (l *configLoader) parseConfig(data map[interface{}]interface{}) (*latest.Config, error) {
 	// Get profile
-	profiles, err := versions.ParseProfile(filepath.Dir(l.ConfigPath()), data, l.options.Profile, l.log)
+	profiles, err := versions.ParseProfile(filepath.Dir(l.ConfigPath()), data, l.options.Profile, l.options.ProfileRefresh, l.log)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -677,6 +677,7 @@ type SourceConfig struct {
 	Branch         string   `yaml:"branch,omitempty"`
 	Tag            string   `yaml:"tag,omitempty"`
 	Revision       string   `yaml:"revision,omitempty"`
+	ConfigName     string   `yaml:"configName,omitempty"`
 
 	Path string `yaml:"path,omitempty"`
 }
@@ -734,10 +735,17 @@ const (
 
 // ProfileConfig defines a profile config
 type ProfileConfig struct {
-	Name    string         `yaml:"name"`
-	Parent  string         `yaml:"parent,omitempty"`
-	Patches []*PatchConfig `yaml:"patches,omitempty"`
-	Replace *ReplaceConfig `yaml:"replace,omitempty"`
+	Name    string           `yaml:"name"`
+	Parent  string           `yaml:"parent,omitempty"`
+	Parents []*ProfileParent `yaml:"parents,omitempty"`
+	Patches []*PatchConfig   `yaml:"patches,omitempty"`
+	Replace *ReplaceConfig   `yaml:"replace,omitempty"`
+}
+
+// ProfileParent defines where to load the profile from
+type ProfileParent struct {
+	Source  *SourceConfig `yaml:"source,omitempty"`
+	Profile string        `yaml:"profile"`
 }
 
 // PatchConfig describes a config patch and how it should be applied

--- a/pkg/devspace/dependency/resolver_test.go
+++ b/pkg/devspace/dependency/resolver_test.go
@@ -2,6 +2,7 @@ package dependency
 
 import (
 	"fmt"
+	"github.com/devspace-cloud/devspace/pkg/devspace/dependency/util"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -51,7 +52,7 @@ func TestResolver(t *testing.T) {
 		t.Fatalf("Error changing working directory: %v", err)
 	}
 
-	DependencyFolderPath = filepath.Join(dir, "dependencyFolder")
+	util.DependencyFolderPath = filepath.Join(dir, "dependencyFolder")
 
 	// Delete temp folder
 	defer func() {
@@ -119,7 +120,7 @@ func TestResolver(t *testing.T) {
 			expectedDependencies: []Dependency{
 				Dependency{
 					ID:        "https://github.com/devspace-cloud/example-dependency.git@f8b2aa8cf8ac03238a28e8f78382b214d619893f:mysubpath",
-					LocalPath: filepath.Join(DependencyFolderPath, "84e3f5121aa5a99b3d26752f40e3935f494312ad82d0e85afc9b6e23c762c705", "mysubpath"),
+					LocalPath: filepath.Join(util.DependencyFolderPath, "84e3f5121aa5a99b3d26752f40e3935f494312ad82d0e85afc9b6e23c762c705", "mysubpath"),
 				},
 			},
 		},
@@ -213,7 +214,7 @@ func TestResolver(t *testing.T) {
 			err = os.Remove(path)
 			assert.NilError(t, err, "Error removing file in testCase %s", testCase.name)
 		}
-		os.RemoveAll(DependencyFolderPath) //No error catch because it doesn't need to exist
+		os.RemoveAll(util.DependencyFolderPath) //No error catch because it doesn't need to exist
 
 	}
 }
@@ -280,7 +281,7 @@ func TestGetDependencyID(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		id := (&resolver{}).getDependencyID(testCase.baseBath, testCase.dependency)
+		id := util.GetDependencyID(testCase.baseBath, testCase.dependency.Source, testCase.dependency.Profile)
 		assert.Equal(t, testCase.expectedID, id, "Dependency has wrong id in testCase %s", testCase.name)
 	}
 }

--- a/pkg/devspace/dependency/util/util.go
+++ b/pkg/devspace/dependency/util/util.go
@@ -1,0 +1,130 @@
+package util
+
+import (
+	"github.com/devspace-cloud/devspace/pkg/devspace/config/versions/latest"
+	"github.com/devspace-cloud/devspace/pkg/util/git"
+	"github.com/devspace-cloud/devspace/pkg/util/hash"
+	"github.com/devspace-cloud/devspace/pkg/util/log"
+	"github.com/mitchellh/go-homedir"
+	"github.com/pkg/errors"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+var authRegEx = regexp.MustCompile("^(https?:\\/\\/)[^:]+:[^@]+@(.*)$")
+
+// DependencyFolder is the dependency folder in the home directory of the user
+const DependencyFolder = ".devspace/dependencies"
+
+// DependencyFolderPath will be filled during init
+var DependencyFolderPath string
+
+func init() {
+	// Make sure dependency folder exists locally
+	homedir, _ := homedir.Dir()
+
+	DependencyFolderPath = filepath.Join(homedir, filepath.FromSlash(DependencyFolder))
+}
+
+func DownloadDependency(basePath string, source *latest.SourceConfig, profile string, update bool, log log.Logger) (ID string, localPath string, err error) {
+	ID = GetDependencyID(basePath, source, profile)
+
+	// Resolve source
+	if source.Git != "" {
+		gitPath := strings.TrimSpace(source.Git)
+
+		os.MkdirAll(DependencyFolderPath, 0755)
+		localPath = filepath.Join(DependencyFolderPath, hash.String(ID))
+
+		// Check if dependency exists
+		_, err := os.Stat(localPath)
+		if err != nil {
+			update = true
+		}
+
+		// Update dependency
+		if update {
+			repo, err := git.NewGitCLIRepository(localPath)
+			if err != nil {
+				return "", "", err
+			}
+
+			err = repo.Clone(git.CloneOptions{
+				URL:            gitPath,
+				Tag:            source.Tag,
+				Branch:         source.Branch,
+				Commit:         source.Revision,
+				Args:           source.CloneArgs,
+				DisableShallow: source.DisableShallow,
+			})
+			if err != nil {
+				return "", "", errors.Wrap(err, "clone repository")
+			}
+
+			log.Donef("Pulled %s", ID)
+		}
+	} else if source.Path != "" {
+		if filepath.IsAbs(source.Path) {
+			localPath = source.Path
+		} else {
+			localPath, err = filepath.Abs(filepath.Join(basePath, filepath.FromSlash(source.Path)))
+			if err != nil {
+				return "", "", errors.Wrap(err, "filepath absolute")
+			}
+		}
+	}
+
+	if source.SubPath != "" {
+		localPath = filepath.Join(localPath, filepath.FromSlash(source.SubPath))
+	}
+
+	return ID, localPath, nil
+}
+
+func GetDependencyID(basePath string, source *latest.SourceConfig, profile string) string {
+	if source.Git != "" {
+		// Erase authentication credentials
+		id := strings.TrimSpace(source.Git)
+		id = authRegEx.ReplaceAllString(id, "$1$2")
+
+		if source.Tag != "" {
+			id += "@" + source.Tag
+		} else if source.Branch != "" {
+			id += "@" + source.Branch
+		} else if source.Revision != "" {
+			id += "@" + source.Revision
+		}
+		if source.SubPath != "" {
+			id += ":" + source.SubPath
+		}
+		if profile != "" {
+			id += " - profile " + profile
+		}
+		if len(source.CloneArgs) > 0 {
+			id += " - with clone args " + strings.Join(source.CloneArgs, " ")
+		}
+
+		return id
+	} else if source.Path != "" {
+		// Check if it's an git repo
+		filePath := source.Path
+		if !filepath.IsAbs(source.Path) {
+			filePath = filepath.Join(basePath, source.Path)
+		}
+
+		remote, err := git.GetRemote(filePath)
+		if err == nil {
+			return remote
+		}
+
+		if profile != "" {
+			filePath += " - profile " + profile
+		}
+
+		return filePath
+	}
+
+	return ""
+}

--- a/pkg/devspace/dependency/util/util.go
+++ b/pkg/devspace/dependency/util/util.go
@@ -74,14 +74,15 @@ func DownloadDependency(basePath string, source *latest.SourceConfig, profile st
 			os.MkdirAll(localPath, 0755)
 
 			// Check if dependency exists
-			_, err := os.Stat(localPath)
+			configPath := filepath.Join(localPath, constants.DefaultConfigPath)
+			_, err := os.Stat(configPath)
 			if err != nil {
 				update = true
 			}
 
 			if update {
 				// Create the file
-				out, err := os.Create(filepath.Join(localPath, constants.DefaultConfigPath))
+				out, err := os.Create(configPath)
 				if err != nil {
 					return "", "", err
 				}

--- a/pkg/devspace/upgrade/upgrade.go
+++ b/pkg/devspace/upgrade/upgrade.go
@@ -2,6 +2,7 @@ package upgrade
 
 import (
 	"errors"
+	"os"
 	"regexp"
 	"sync"
 
@@ -33,10 +34,12 @@ func eraseVersionPrefix(version string) (string, error) {
 
 // PrintUpgradeMessage prints an upgrade message if there is a new version available
 func PrintUpgradeMessage() {
-	// Get version of current binary
-	latestVersion := NewerVersionAvailable()
-	if latestVersion != "" {
-		log.GetInstance().Warnf("There is a newer version of DevSpace: v%s. Run `devspace upgrade` to upgrade to the newest version.\n", latestVersion)
+	if os.Getenv("DEVSPACE_SKIP_VERSION_CHECK") != "true" {
+		// Get version of current binary
+		latestVersion := NewerVersionAvailable()
+		if latestVersion != "" {
+			log.GetInstance().Warnf("There is a newer version of DevSpace: v%s. Run `devspace upgrade` to upgrade to the newest version.\n", latestVersion)
+		}
 	}
 }
 


### PR DESCRIPTION
### Changes
- Fixes an issue where add patches wouldn't work as expected
- Adds a new environment variable `DEVSPACE_SKIP_VERSION_CHECK` to skip the version check (#1198)
- Adds a new config option `profiles.*.parents` that can define multiple parent profiles: (#1199)
```yaml
version: v1beta9
profiles:
- name: multi-parents
  # New field that applies the profile deployments first and then the profile images
  parents:
  - profile: deployments
  - profile: images
- name: deployments
  replace:
   deployments:
   - name: my-deployment
     helm:
       componentChart: true
       values:
         containers:
         - name: test
- name: images
  replace:
    images:
      test:
        image: mydockeruser/devspace
        createPullSecret: true
```
- Adds a new config option `profiles.*.parents.*.source` that can define profiles that lie in a different `devspace.yaml`: (#1200)
```yaml
version: v1beta9
profiles:
- name: dev
  parents:
  - profile: images
    source:
      path: other-folder # devspace.yaml will be automatically appended to the path (same syntax as with dependencies)
      # or load from url
      # path: https://raw.githubusercontent.com/my-org/my-repo/master/devspace.yaml
      # or load from git
      # git: https://github.com/devspace-cloud/devspace.git 
  - profile: deployments
    source:
      path: other-folder-2
```
