### PR TITLE
fix: several kaniko issues

### DIFF
--- a/pkg/devspace/build/builder/helper/util.go
+++ b/pkg/devspace/build/builder/helper/util.go
@@ -130,14 +130,14 @@ func RewriteDockerfile(dockerfile string, entrypoint []string, cmd []string, add
 
 		if len(entrypoint) == 0 {
 			if len(oldEntrypoint) == 0 {
-				if len(oldCmd) == 0 {
+				if len(cmd) == 0 && len(oldCmd) == 0 {
 					return "", errors.Errorf("cannot inject restart helper into Dockerfile because neither ENTRYPOINT nor CMD was found.\n\nHow to fix this:\n- Option A: Define an ENTRYPOINT (or CMD) in your Dockerfile\n- Option B: Set `images.*.entrypoint` option in your devspace.yaml")
 				}
 				log.Warn("Using CMD statement for injecting restart helper because ENTRYPOINT is missing in Dockerfile and `images.*.entrypoint` is also not configured")
 			}
 
 			entrypoint = oldEntrypoint
-			if len(cmd) == 0 {
+			if len(cmd) == 0 && len(oldCmd) > 0 {
 				cmd = oldCmd
 			}
 		} else if len(cmd) == 0 && len(oldCmd) > 0 {

--- a/pkg/devspace/build/builder/kaniko/build_pod.go
+++ b/pkg/devspace/build/builder/kaniko/build_pod.go
@@ -17,7 +17,7 @@ import (
 )
 
 // The kaniko build image we use by default
-const kanikoBuildImage = "gcr.io/kaniko-project/executor:v0.17.1"
+const kanikoBuildImage = "gcr.io/kaniko-project/executor:v1.3.0"
 
 // The context path within the kaniko pod
 const kanikoContextPath = "/context"
@@ -75,6 +75,11 @@ func (b *Builder) getBuildPod(buildID string, options *types.ImageBuildOptions, 
 		for _, tag := range b.helper.ImageConf.Tags {
 			kanikoArgs = append(kanikoArgs, "--destination="+b.helper.ImageName+":"+tag)
 		}
+	}
+
+	// set target
+	if options.Target != "" {
+		kanikoArgs = append(kanikoArgs, "--target="+options.Target)
 	}
 
 	// set snapshot mode

--- a/pkg/devspace/build/builder/kaniko/kaniko.go
+++ b/pkg/devspace/build/builder/kaniko/kaniko.go
@@ -249,7 +249,7 @@ func (b *Builder) BuildImage(contextPath, dockerfilePath string, entrypoint []st
 			defer os.RemoveAll(tempDir)
 
 			scriptPath := filepath.Join(tempDir, restart.ScriptName)
-			remoteFolder := filepath.Join(kanikoContextPath, ".devspace", ".devspace")
+			remoteFolder := filepath.ToSlash(filepath.Join(kanikoContextPath, ".devspace", ".devspace"))
 			err = ioutil.WriteFile(scriptPath, []byte(restart.HelperScript), 0777)
 			if err != nil {
 				return errors.Wrap(err, "write restart helper script")
@@ -264,7 +264,7 @@ func (b *Builder) BuildImage(contextPath, dockerfilePath string, entrypoint []st
 			// copy the helper script into the container
 			err = b.helper.KubeClient.Copy(buildPod, buildPod.Spec.InitContainers[0].Name, remoteFolder, scriptPath, []string{})
 			if err != nil {
-				return errors.Errorf("error uploading dockerfile to container: %v", err)
+				return errors.Errorf("error uploading helper script to container: %v", err)
 			}
 
 			// change permissions for the execution script
@@ -275,7 +275,7 @@ func (b *Builder) BuildImage(contextPath, dockerfilePath string, entrypoint []st
 
 			// remove the .dockerignore since .devspace is usually ignored and we want to sneak our helper script in
 			// this shouldn't be any issue since the context was already pruned in the copy step beforehand
-			_, _, err = b.helper.KubeClient.ExecBuffered(buildPod, buildPod.Spec.InitContainers[0].Name, []string{"rm", filepath.Join(kanikoContextPath, ".dockerignore")}, nil)
+			_, _, err = b.helper.KubeClient.ExecBuffered(buildPod, buildPod.Spec.InitContainers[0].Name, []string{"rm", filepath.ToSlash(filepath.Join(kanikoContextPath, ".dockerignore"))}, nil)
 			if err != nil {
 				if _, ok := err.(exec.CodeExitError); !ok {
 					return errors.Errorf("error executing command 'rm .dockerignore' in init container: %v", err)


### PR DESCRIPTION
### Changes
- Updates kaniko default version to v1.3.0
- Fixes an issue in kaniko build where the target was not set correctly
- Fixes an issue in kaniko build on windows where the restart helper couldn't be injected
- Fixes an issue in kaniko build on windows where files were not executable