### PR TITLE
fix: fixes an initial sync wait race (#1223)

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -287,7 +287,7 @@ func (cmd *DeployCmd) Run(f factory.Factory, plugins []plugin.Metadata, cobraCmd
 
 	// wait if necessary
 	if cmd.Wait {
-		report, err := f.NewAnalyzer(client, f.GetLog()).CreateReport(client.Namespace(), analyze.Options{Wait: true, Patient: true, Timeout: cmd.Timeout})
+		report, err := f.NewAnalyzer(client, f.GetLog()).CreateReport(client.Namespace(), analyze.Options{Wait: true, Patient: true, Timeout: cmd.Timeout, IgnorePodRestarts: true})
 		if err != nil {
 			return errors.Wrap(err, "analyze")
 		}

--- a/cmd/dev.go
+++ b/cmd/dev.go
@@ -349,7 +349,7 @@ func (cmd *DevCmd) buildAndDeploy(f factory.Factory, config *latest.Config, gene
 
 	// Wait if necessary
 	if cmd.Wait {
-		report, err := f.NewAnalyzer(client, f.GetLog()).CreateReport(client.Namespace(), analyze.Options{Wait: true, Patient: true, Timeout: cmd.Timeout})
+		report, err := f.NewAnalyzer(client, f.GetLog()).CreateReport(client.Namespace(), analyze.Options{Wait: true, Patient: true, Timeout: cmd.Timeout, IgnorePodRestarts: true})
 		if err != nil {
 			return 0, errors.Wrap(err, "analyze")
 		}

--- a/cmd/dev.go
+++ b/cmd/dev.go
@@ -75,8 +75,6 @@ type DevCmd struct {
 	log          log.Logger
 }
 
-const interactiveDefaultPickerValue = "Open Picker"
-
 // NewDevCmd creates a new devspace dev command
 func NewDevCmd(f factory.Factory, globalFlags *flags.GlobalFlags, plugins []plugin.Metadata) *cobra.Command {
 	cmd := &DevCmd{

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -129,6 +129,11 @@ func (cmd *RestartCmd) Run(f factory.Factory, plugins []plugin.Metadata, cobraCm
 				return errors.Errorf("Error selecting pod: %v", err)
 			}
 
+			err = services.InjectDevSpaceHelper(client, pod, container.Name, cmd.log)
+			if err != nil {
+				return errors.Wrap(err, "inject devspace helper")
+			}
+
 			stdOut, stdErr, err := client.ExecBuffered(pod, container.Name, []string{services.DevSpaceHelperContainerPath, "restart"}, nil)
 			if err != nil {
 				return fmt.Errorf("error restarting container %s in pod %s/%s: %s %s => %v", container.Name, pod.Namespace, pod.Name, string(stdOut), string(stdErr), err)

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -110,7 +110,7 @@ func (cmd *SyncCmd) Run(f factory.Factory, plugins []plugin.Metadata, cobraCmd *
 			return err
 		}
 	} else {
-		logger.Warnf("You are using `devspace sync` without a devspace.yaml, use the flag `--config` to specify a config")
+		logger.Warnf("If you want to use the sync paths from `devspace.yaml`, use the `--config=devspace.yaml` flag for this command.")
 	}
 
 	// Use last context if specified

--- a/helper/cmd/root.go
+++ b/helper/cmd/root.go
@@ -10,7 +10,7 @@ import (
 // NewRootCmd returns a new root command
 func NewRootCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "devspace",
+		Use:   "devspace-restart-helper",
 		Short: "DevSpace Utility CLI",
 	}
 }

--- a/helper/main.go
+++ b/helper/main.go
@@ -1,7 +1,12 @@
 package main
 
-import "github.com/devspace-cloud/devspace/helper/cmd"
+import (
+	"github.com/devspace-cloud/devspace/helper/cmd"
+	"math/rand"
+	"time"
+)
 
 func main() {
+	rand.Seed(time.Now().UTC().UnixNano())
 	cmd.Execute()
 }

--- a/pkg/devspace/build/builder/custom/custom.go
+++ b/pkg/devspace/build/builder/custom/custom.go
@@ -26,15 +26,15 @@ type Builder struct {
 	imageConf *latest.ImageConfig
 
 	imageConfigName string
-	imageTag        string
+	imageTags       []string
 }
 
 // NewBuilder creates a new custom builder
-func NewBuilder(imageConfigName string, imageConf *latest.ImageConfig, imageTag string) *Builder {
+func NewBuilder(imageConfigName string, imageConf *latest.ImageConfig, imageTags []string) *Builder {
 	return &Builder{
 		imageConfigName: imageConfigName,
 		imageConf:       imageConf,
-		imageTag:        imageTag,
+		imageTags:       imageTags,
 	}
 }
 
@@ -86,24 +86,18 @@ func (b *Builder) Build(log logpkg.Logger) error {
 	// Build arguments
 	args := []string{}
 
+	// add args
 	for _, arg := range b.imageConf.Build.Custom.Args {
 		args = append(args, arg)
 	}
 
-	if len(b.imageConf.Tags) == 0 {
+	// add tags
+	for _, tag := range b.imageConf.Tags {
 		if b.imageConf.Build.Custom.ImageFlag != "" {
 			args = append(args, b.imageConf.Build.Custom.ImageFlag)
 		}
 
-		args = append(args, b.imageConf.Image+":"+b.imageTag)
-	} else {
-		for _, tag := range b.imageConf.Tags {
-			if b.imageConf.Build.Custom.ImageFlag != "" {
-				args = append(args, b.imageConf.Build.Custom.ImageFlag)
-			}
-
-			args = append(args, b.imageConf.Image+":"+tag)
-		}
+		args = append(args, b.imageConf.Image+":"+tag)
 	}
 
 	for _, arg := range b.imageConf.Build.Custom.AppendArgs {
@@ -121,7 +115,7 @@ func (b *Builder) Build(log logpkg.Logger) error {
 		writer = log
 	}
 
-	log.Infof("Build %s:%s with custom command %s %s", b.imageConf.Image, b.imageTag, b.imageConf.Build.Custom.Command, strings.Join(args, " "))
+	log.Infof("Build %s:%s with custom command %s %s", b.imageConf.Image, b.imageTags[0], b.imageConf.Build.Custom.Command, strings.Join(args, " "))
 
 	err := cmd.Run(writer, writer, nil)
 	if err != nil {

--- a/pkg/devspace/build/builder/helper/helper.go
+++ b/pkg/devspace/build/builder/helper/helper.go
@@ -26,7 +26,7 @@ type BuildHelper struct {
 
 	EngineName string
 	ImageName  string
-	ImageTag   string
+	ImageTags  []string
 	Entrypoint []string
 	Cmd        []string
 
@@ -40,7 +40,7 @@ type BuildHelperInterface interface {
 }
 
 // NewBuildHelper creates a new build helper for a certain engine
-func NewBuildHelper(config *latest.Config, kubeClient kubectl.Client, engineName string, imageConfigName string, imageConf *latest.ImageConfig, imageTag string, isDev bool) *BuildHelper {
+func NewBuildHelper(config *latest.Config, kubeClient kubectl.Client, engineName string, imageConfigName string, imageConf *latest.ImageConfig, imageTags []string, isDev bool) *BuildHelper {
 	var (
 		dockerfilePath, contextPath = GetDockerfileAndContext(imageConf)
 		imageName                   = imageConf.Image
@@ -78,7 +78,7 @@ func NewBuildHelper(config *latest.Config, kubeClient kubectl.Client, engineName
 		ContextPath:    contextPath,
 
 		ImageName:  imageName,
-		ImageTag:   imageTag,
+		ImageTags:  imageTags,
 		EngineName: engineName,
 
 		Entrypoint: entrypoint,
@@ -103,7 +103,7 @@ func (b *BuildHelper) Build(imageBuilder BuildHelperInterface, log log.Logger) e
 		return errors.Errorf("Couldn't determine absolute path for %s", b.ContextPath)
 	}
 
-	log.Infof("Building image '%s:%s' with engine '%s'", b.ImageName, b.ImageTag, b.EngineName)
+	log.Infof("Building image '%s:%s' with engine '%s'", b.ImageName, b.ImageTags[0], b.EngineName)
 
 	// Build Image
 	err = imageBuilder.BuildImage(absoluteContextPath, absoluteDockerfilePath, b.Entrypoint, b.Cmd, log)

--- a/pkg/devspace/build/builder/kaniko/build_pod.go
+++ b/pkg/devspace/build/builder/kaniko/build_pod.go
@@ -69,12 +69,8 @@ func (b *Builder) getBuildPod(buildID string, options *types.ImageBuildOptions, 
 	}
 
 	// specify destinations
-	if len(b.helper.ImageConf.Tags) == 0 {
-		kanikoArgs = append(kanikoArgs, "--destination="+b.FullImageName)
-	} else {
-		for _, tag := range b.helper.ImageConf.Tags {
-			kanikoArgs = append(kanikoArgs, "--destination="+b.helper.ImageName+":"+tag)
-		}
+	for _, tag := range b.helper.ImageTags {
+		kanikoArgs = append(kanikoArgs, "--destination="+b.helper.ImageName+":"+tag)
 	}
 
 	// set target

--- a/pkg/devspace/build/builder/kaniko/kaniko.go
+++ b/pkg/devspace/build/builder/kaniko/kaniko.go
@@ -56,7 +56,7 @@ type Builder struct {
 const waitTimeout = 20 * time.Minute
 
 // NewBuilder creates a new kaniko.Builder instance
-func NewBuilder(config *latest.Config, dockerClient docker.Client, kubeClient kubectl.Client, imageConfigName string, imageConf *latest.ImageConfig, imageTag string, isDev bool, log logpkg.Logger) (builder.Interface, error) {
+func NewBuilder(config *latest.Config, dockerClient docker.Client, kubeClient kubectl.Client, imageConfigName string, imageConf *latest.ImageConfig, imageTags []string, isDev bool, log logpkg.Logger) (builder.Interface, error) {
 	buildNamespace := kubeClient.Namespace()
 	if imageConf.Build.Kaniko.Namespace != "" {
 		buildNamespace = imageConf.Build.Kaniko.Namespace
@@ -74,13 +74,13 @@ func NewBuilder(config *latest.Config, dockerClient docker.Client, kubeClient ku
 
 	builder := &Builder{
 		PullSecretName: pullSecretName,
-		FullImageName:  imageConf.Image + ":" + imageTag,
+		FullImageName:  imageConf.Image + ":" + imageTags[0],
 		BuildNamespace: buildNamespace,
 
 		allowInsecureRegistry: allowInsecurePush,
 
 		dockerClient: dockerClient,
-		helper:       helper.NewBuildHelper(config, kubeClient, EngineName, imageConfigName, imageConf, imageTag, isDev),
+		helper:       helper.NewBuildHelper(config, kubeClient, EngineName, imageConfigName, imageConf, imageTags, isDev),
 	}
 
 	// create pull secret

--- a/pkg/devspace/config/loader/predefined_vars.go
+++ b/pkg/devspace/config/loader/predefined_vars.go
@@ -36,6 +36,19 @@ var predefinedVars = map[string]func(loader *configLoader) (string, error){
 	"DEVSPACE_TIMESTAMP": func(loader *configLoader) (string, error) {
 		return strconv.FormatInt(time.Now().Unix(), 10), nil
 	},
+	"DEVSPACE_GIT_BRANCH": func(loader *configLoader) (string, error) {
+		configPath := loader.options.BasePath
+		if configPath == "" {
+			configPath = loader.ConfigPath()
+		}
+
+		branch, err := git.GetBranch(filepath.Dir(configPath))
+		if err != nil {
+			return "", fmt.Errorf("Error retrieving git branch: %v, but predefined var DEVSPACE_GIT_BRANCH is used", err)
+		}
+
+		return branch, nil
+	},
 	"DEVSPACE_GIT_COMMIT": func(loader *configLoader) (string, error) {
 		configPath := loader.options.BasePath
 		if configPath == "" {

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -53,6 +53,10 @@ type ImageConfig struct {
 	// the build process. If this is empty, devspace will generate a random tag
 	Tags []string `yaml:"tags,omitempty" json:"tags,omitempty"`
 
+	// If TagsAppendRandom is true, for all tags defined for this image a random suffix in
+	// the form of '-xxxxx' will be appended
+	TagsAppendRandom bool `yaml:"tagsAppendRandom,omitempty" json:"tagsAppendRandom,omitempty"`
+
 	// Specifies a path (relative or absolute) to the dockerfile
 	Dockerfile string `yaml:"dockerfile,omitempty" json:"dockerfile,omitempty"`
 

--- a/pkg/devspace/services/reverse_port_forwarding.go
+++ b/pkg/devspace/services/reverse_port_forwarding.go
@@ -52,7 +52,7 @@ func (serviceClient *client) startReversePortForwarding(portForwarding *latest.P
 	}
 
 	// make sure the devspace helper binary is injected
-	err = serviceClient.injectDevSpaceHelper(pod, container.Name)
+	err = InjectDevSpaceHelper(serviceClient.client, pod, container.Name, serviceClient.log)
 	if err != nil {
 		return err
 	}

--- a/pkg/devspace/tunnel/client.go
+++ b/pkg/devspace/tunnel/client.go
@@ -40,6 +40,7 @@ loop:
 			requestId, err := uuid.Parse(m.RequestId)
 			if err != nil {
 				log.Errorf("%s; failed parsing session uuid from stream, skipping", m.RequestId)
+				continue
 			}
 			session, exists := tunnel.GetSession(requestId)
 			if exists == false {
@@ -94,7 +95,6 @@ func ReadFromSession(session *tunnel.Session, sessionsOut chan<- *tunnel.Session
 	conn := session.Conn
 	buff := make([]byte, bufferSize)
 	for {
-		//_ = conn.SetReadDeadline(time.Now().Add(time.Second))
 		br, err := conn.Read(buff)
 		if err != nil {
 			if err != io.EOF {

--- a/pkg/util/git/helper.go
+++ b/pkg/util/git/helper.go
@@ -8,6 +8,21 @@ import (
 	"strings"
 )
 
+// GetBranch retrieves the current HEADs name
+func GetBranch(localPath string) (string, error) {
+	repo, err := git.PlainOpen(localPath)
+	if err != nil {
+		return "", errors.Wrap(err, "git open")
+	}
+
+	head, err := repo.Head()
+	if err != nil {
+		return "", errors.Wrap(err, "get head")
+	}
+
+	return head.Name().Short(), nil
+}
+
 // GetHash retrieves the current HEADs hash
 func GetHash(localPath string) (string, error) {
 	repo, err := git.PlainOpen(localPath)

--- a/pkg/util/randutil/rand.go
+++ b/pkg/util/randutil/rand.go
@@ -6,16 +6,15 @@ import (
 	"regexp"
 )
 
-//GenerateRandomString returns a random strin containing only letters
+// GenerateRandomString returns a random strin containing only letters
 func GenerateRandomString(length int) (string, error) {
 	randBytes := make([]byte, length*2)
 
 	_, randErr := rand.Read(randBytes)
-
 	if randErr != nil {
 		return "", randErr
 	}
-	regex := regexp.MustCompile("[^a-zA-Z0-9]")
 
+	regex := regexp.MustCompile("[^a-zA-Z0-9]")
 	return regex.ReplaceAllString(base64.URLEncoding.EncodeToString(randBytes), "")[0:length], nil
 }


### PR DESCRIPTION
### Changes
- Fixes a race condition in sync where the initial sync wouldn't wait for uploading a single file (#1223)
- Fixes an issue where `devspace restart` wouldn't work without running `devspace dev` or `devspace sync` prior
- Fixes an issue where pod restarts could lead to a timeout during `devspace deploy/dev --wait`
- New option `tagsAppendRandom` that automatically adds a random suffix to each tag and avoids the rebuilding problem described in #1188
- New predefined variable `DEVSPACE_GIT_BRANCH` that holds the git branch name