### PR TITLE
hooks, dependencies & kaniko changes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,31 +45,9 @@ jobs:
       - name: Test
         run: ./hack/coverage.bash
         shell: bash
-  release:
-    if: startsWith(github.ref, 'refs/tags/v') == true
-    needs: [test-linux]
-    runs-on: macOS-latest
-    steps:
-      - name: Set up Go 1.13
-        uses: actions/setup-go@v1
-        with:
-          go-version: 1.13
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
-      - name: Compile binaries
-        run: ./hack/build-all.bash
-        env:
-          ANALYTICS_TOKEN: ${{ secrets.ANALYTICS_TOKEN }}
-          ANALYTICS_ENDPOINT_EVENT: ${{ secrets.ANALYTICS_ENDPOINT_EVENT }}
-          ANALYTICS_ENDPOINT_USER: ${{ secrets.ANALYTICS_ENDPOINT_USER }}
-      - name: Publish
-        uses: FabianKramm/release-asset-action@v1
-        with:
-          pattern: "release/*"
-          github-token: ${{ secrets.GITHUB_TOKEN }}
   release-ui:
     if: startsWith(github.ref, 'refs/tags/v') == true
-    needs: [test-linux]
+    needs: [ test-linux ]
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
@@ -90,6 +68,32 @@ jobs:
           NPM_REGISTRY_TOKEN: ${{ secrets.NPM_DEVSPACE_REGISTRY_TOKEN }}
           CI: "false"
         run: ./hack/build-ui.bash
+      - name: Upload ui tar
+        uses: actions/upload-artifact@v2
+        with:
+          name: ui-tar
+          path: release/ui.tar.gz
+  release:
+    if: startsWith(github.ref, 'refs/tags/v') == true
+    needs: [ release-ui ]
+    runs-on: macOS-latest
+    steps:
+      - name: Download ui tar
+        uses: actions/download-artifact@v2
+          with:
+            name: ui-tar
+      - name: Set up Go 1.13
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v1
+      - name: Compile binaries
+        run: ./hack/build-all.bash
+        env:
+          ANALYTICS_TOKEN: ${{ secrets.ANALYTICS_TOKEN }}
+          ANALYTICS_ENDPOINT_EVENT: ${{ secrets.ANALYTICS_ENDPOINT_EVENT }}
+          ANALYTICS_ENDPOINT_USER: ${{ secrets.ANALYTICS_ENDPOINT_USER }}
       - name: Publish
         uses: FabianKramm/release-asset-action@v1
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,8 +80,8 @@ jobs:
     steps:
       - name: Download ui tar
         uses: actions/download-artifact@v2
-          with:
-            name: ui-tar
+        with:
+          name: ui-tar
       - name: Set up Go 1.13
         uses: actions/setup-go@v1
         with:

--- a/assets/assets.go
+++ b/assets/assets.go
@@ -1,0 +1,244 @@
+// Code generated for package assets by go-bindata DO NOT EDIT. (@generated)
+// sources:
+// CHANGELOG.md
+package assets
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func bindataRead(data []byte, name string) ([]byte, error) {
+	gz, err := gzip.NewReader(bytes.NewBuffer(data))
+	if err != nil {
+		return nil, fmt.Errorf("Read %q: %v", name, err)
+	}
+
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, gz)
+	clErr := gz.Close()
+
+	if err != nil {
+		return nil, fmt.Errorf("Read %q: %v", name, err)
+	}
+	if clErr != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+type asset struct {
+	bytes []byte
+	info  os.FileInfo
+}
+
+type bindataFileInfo struct {
+	name    string
+	size    int64
+	mode    os.FileMode
+	modTime time.Time
+}
+
+// Name return file name
+func (fi bindataFileInfo) Name() string {
+	return fi.name
+}
+
+// Size return file size
+func (fi bindataFileInfo) Size() int64 {
+	return fi.size
+}
+
+// Mode return file mode
+func (fi bindataFileInfo) Mode() os.FileMode {
+	return fi.mode
+}
+
+// Mode return file modify time
+func (fi bindataFileInfo) ModTime() time.Time {
+	return fi.modTime
+}
+
+// IsDir return file whether a directory
+func (fi bindataFileInfo) IsDir() bool {
+	return fi.mode&os.ModeDir != 0
+}
+
+// Sys return file is sys mode
+func (fi bindataFileInfo) Sys() interface{} {
+	return nil
+}
+
+var _changelogMd = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x01\x00\x00\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00")
+
+func changelogMdBytes() ([]byte, error) {
+	return bindataRead(
+		_changelogMd,
+		"CHANGELOG.md",
+	)
+}
+
+func changelogMd() (*asset, error) {
+	bytes, err := changelogMdBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "CHANGELOG.md", size: 0, mode: os.FileMode(420), modTime: time.Unix(1537176446, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+// Asset loads and returns the asset for the given name.
+// It returns an error if the asset could not be found or
+// could not be loaded.
+func Asset(name string) ([]byte, error) {
+	cannonicalName := strings.Replace(name, "\\", "/", -1)
+	if f, ok := _bindata[cannonicalName]; ok {
+		a, err := f()
+		if err != nil {
+			return nil, fmt.Errorf("Asset %s can't read by error: %v", name, err)
+		}
+		return a.bytes, nil
+	}
+	return nil, fmt.Errorf("Asset %s not found", name)
+}
+
+// MustAsset is like Asset but panics when Asset would return an error.
+// It simplifies safe initialization of global variables.
+func MustAsset(name string) []byte {
+	a, err := Asset(name)
+	if err != nil {
+		panic("asset: Asset(" + name + "): " + err.Error())
+	}
+
+	return a
+}
+
+// AssetInfo loads and returns the asset info for the given name.
+// It returns an error if the asset could not be found or
+// could not be loaded.
+func AssetInfo(name string) (os.FileInfo, error) {
+	cannonicalName := strings.Replace(name, "\\", "/", -1)
+	if f, ok := _bindata[cannonicalName]; ok {
+		a, err := f()
+		if err != nil {
+			return nil, fmt.Errorf("AssetInfo %s can't read by error: %v", name, err)
+		}
+		return a.info, nil
+	}
+	return nil, fmt.Errorf("AssetInfo %s not found", name)
+}
+
+// AssetNames returns the names of the assets.
+func AssetNames() []string {
+	names := make([]string, 0, len(_bindata))
+	for name := range _bindata {
+		names = append(names, name)
+	}
+	return names
+}
+
+// _bindata is a table, holding each asset generator, mapped to its name.
+var _bindata = map[string]func() (*asset, error){
+	"CHANGELOG.md": changelogMd,
+}
+
+// AssetDir returns the file names below a certain
+// directory embedded in the file by go-bindata.
+// For example if you run go-bindata on data/... and data contains the
+// following hierarchy:
+//     data/
+//       foo.txt
+//       img/
+//         a.png
+//         b.png
+// then AssetDir("data") would return []string{"foo.txt", "img"}
+// AssetDir("data/img") would return []string{"a.png", "b.png"}
+// AssetDir("foo.txt") and AssetDir("notexist") would return an error
+// AssetDir("") will return []string{"data"}.
+func AssetDir(name string) ([]string, error) {
+	node := _bintree
+	if len(name) != 0 {
+		cannonicalName := strings.Replace(name, "\\", "/", -1)
+		pathList := strings.Split(cannonicalName, "/")
+		for _, p := range pathList {
+			node = node.Children[p]
+			if node == nil {
+				return nil, fmt.Errorf("Asset %s not found", name)
+			}
+		}
+	}
+	if node.Func != nil {
+		return nil, fmt.Errorf("Asset %s not found", name)
+	}
+	rv := make([]string, 0, len(node.Children))
+	for childName := range node.Children {
+		rv = append(rv, childName)
+	}
+	return rv, nil
+}
+
+type bintree struct {
+	Func     func() (*asset, error)
+	Children map[string]*bintree
+}
+
+var _bintree = &bintree{nil, map[string]*bintree{
+	"CHANGELOG.md": &bintree{changelogMd, map[string]*bintree{}},
+}}
+
+// RestoreAsset restores an asset under the given directory
+func RestoreAsset(dir, name string) error {
+	data, err := Asset(name)
+	if err != nil {
+		return err
+	}
+	info, err := AssetInfo(name)
+	if err != nil {
+		return err
+	}
+	err = os.MkdirAll(_filePath(dir, filepath.Dir(name)), os.FileMode(0755))
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(_filePath(dir, name), data, info.Mode())
+	if err != nil {
+		return err
+	}
+	err = os.Chtimes(_filePath(dir, name), info.ModTime(), info.ModTime())
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// RestoreAssets restores an asset under the given directory recursively
+func RestoreAssets(dir, name string) error {
+	children, err := AssetDir(name)
+	// File
+	if err != nil {
+		return RestoreAsset(dir, name)
+	}
+	// Dir
+	for _, child := range children {
+		err = RestoreAssets(dir, filepath.Join(name, child))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func _filePath(dir, name string) string {
+	cannonicalName := strings.Replace(name, "\\", "/", -1)
+	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
+}

--- a/pkg/devspace/build/build.go
+++ b/pkg/devspace/build/build.go
@@ -83,7 +83,7 @@ func (c *controller) Build(options *Options, log logpkg.Logger) (map[string]stri
 	}
 
 	// Execute before images build hook
-	err := c.hookExecuter.Execute(hook.Before, hook.StageImages, hook.All, log)
+	err := c.hookExecuter.Execute(hook.Before, hook.StageImages, hook.All, hook.Context{Client: c.client}, log)
 	if err != nil {
 		return nil, err
 	}
@@ -146,6 +146,7 @@ func (c *controller) Build(options *Options, log logpkg.Logger) (map[string]stri
 			// Build the image
 			err = builder.Build(log)
 			if err != nil {
+				c.hookExecuter.OnError(hook.StageImages, []string{hook.All}, hook.Context{Client: c.client, Error: err}, log)
 				return nil, err
 			}
 
@@ -192,6 +193,7 @@ func (c *controller) Build(options *Options, log logpkg.Logger) (map[string]stri
 
 			select {
 			case err := <-errChan:
+				c.hookExecuter.OnError(hook.StageImages, []string{hook.All}, hook.Context{Client: c.client, Error: err}, log)
 				return nil, err
 			case done := <-cacheChan:
 				imagesToBuild--
@@ -213,7 +215,7 @@ func (c *controller) Build(options *Options, log logpkg.Logger) (map[string]stri
 	}
 
 	// Execute after images build hook
-	err = c.hookExecuter.Execute(hook.After, hook.StageImages, hook.All, log)
+	err = c.hookExecuter.Execute(hook.After, hook.StageImages, hook.All, hook.Context{Client: c.client}, log)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -708,8 +708,9 @@ type HookConfig struct {
 
 // HookWhenConfig defines when the hook should be executed
 type HookWhenConfig struct {
-	Before *HookWhenAtConfig `yaml:"before,omitempty" json:"before,omitempty"`
-	After  *HookWhenAtConfig `yaml:"after,omitempty" json:"after,omitempty"`
+	Before  *HookWhenAtConfig `yaml:"before,omitempty" json:"before,omitempty"`
+	After   *HookWhenAtConfig `yaml:"after,omitempty" json:"after,omitempty"`
+	OnError *HookWhenAtConfig `yaml:"onError,omitempty" json:"onError,omitempty"`
 }
 
 // HookWhenAtConfig defines at which stage the hook should be executed

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -133,6 +133,9 @@ type KanikoConfig struct {
 	// the image name of the kaniko pod to use
 	Image string `yaml:"image,omitempty" json:"image,omitempty"`
 
+	// the image to init the kaniko pod
+	InitImage string `yaml:"initImage,omitempty" json:"initImage,omitempty"`
+
 	// additional arguments that should be passed to kaniko
 	Args []string `yaml:"args,omitempty" json:"args,omitempty"`
 
@@ -144,6 +147,12 @@ type KanikoConfig struct {
 
 	// the pull secret to mount by default
 	PullSecret string `yaml:"pullSecret,omitempty" json:"pullSecret,omitempty"`
+
+	// the node selector to use for the kaniko pod
+	NodeSelector map[string]string `yaml:"nodeSelector,omitempty" json:"nodeSelector,omitempty"`
+
+	// the service account to use for the kaniko pod
+	ServiceAccount string `yaml:"serviceAccount,omitempty" json:"serviceAccount,omitempty"`
 
 	// additional mounts that will be added to the build pod
 	AdditionalMounts []KanikoAdditionalMount `yaml:"additionalMounts,omitempty" json:"additionalMounts,omitempty"`

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -675,12 +675,22 @@ type TerminalConfig struct {
 
 // DependencyConfig defines the devspace dependency
 type DependencyConfig struct {
-	Name               string        `yaml:"name" json:"name"`
-	Source             *SourceConfig `yaml:"source" json:"source"`
-	Profile            string        `yaml:"profile,omitempty" json:"profile,omitempty"`
-	SkipBuild          *bool         `yaml:"skipBuild,omitempty" json:"skipBuild,omitempty"`
-	IgnoreDependencies *bool         `yaml:"ignoreDependencies,omitempty" json:"ignoreDependencies,omitempty"`
-	Namespace          string        `yaml:"namespace,omitempty" json:"namespace,omitempty"`
+	Name               string          `yaml:"name" json:"name"`
+	Source             *SourceConfig   `yaml:"source" json:"source"`
+	Profile            string          `yaml:"profile,omitempty" json:"profile,omitempty"`
+	Vars               []DependencyVar `yaml:"vars,omitempty" json:"vars,omitempty"`
+	SkipBuild          *bool           `yaml:"skipBuild,omitempty" json:"skipBuild,omitempty"`
+	IgnoreDependencies *bool           `yaml:"ignoreDependencies,omitempty" json:"ignoreDependencies,omitempty"`
+	Namespace          string          `yaml:"namespace,omitempty" json:"namespace,omitempty"`
+}
+
+// DependencyVar holds an override value for a config variable
+type DependencyVar struct {
+	// Name is the name of the variable
+	Name string `yaml:"name,omitempty" json:"name,omitempty"`
+
+	// Value is the value to override
+	Value string `yaml:"value,omitempty" json:"value,omitempty"`
 }
 
 // SourceConfig defines the dependency source

--- a/pkg/devspace/config/versions/versions.go
+++ b/pkg/devspace/config/versions/versions.go
@@ -229,7 +229,7 @@ func getProfiles(basePath string, data map[interface{}]interface{}, profile stri
 					}
 
 					if profileConfig.Parents[i].Source != nil {
-						_, localPath, err := dependencyutil.DownloadDependency(basePath, profileConfig.Parents[i].Source, profileConfig.Parents[i].Profile, update, log)
+						_, localPath, err := dependencyutil.DownloadDependency(basePath, profileConfig.Parents[i].Source, profileConfig.Parents[i].Profile, nil, update, log)
 						if err != nil {
 							return err
 						}

--- a/pkg/devspace/dependency/resolver_test.go
+++ b/pkg/devspace/dependency/resolver_test.go
@@ -281,7 +281,7 @@ func TestGetDependencyID(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		id := util.GetDependencyID(testCase.baseBath, testCase.dependency.Source, testCase.dependency.Profile)
+		id := util.GetDependencyID(testCase.baseBath, testCase.dependency.Source, testCase.dependency.Profile, nil)
 		assert.Equal(t, testCase.expectedID, id, "Dependency has wrong id in testCase %s", testCase.name)
 	}
 }

--- a/pkg/devspace/dependency/util/util.go
+++ b/pkg/devspace/dependency/util/util.go
@@ -31,8 +31,8 @@ func init() {
 	DependencyFolderPath = filepath.Join(homedir, filepath.FromSlash(DependencyFolder))
 }
 
-func DownloadDependency(basePath string, source *latest.SourceConfig, profile string, update bool, log log.Logger) (ID string, localPath string, err error) {
-	ID = GetDependencyID(basePath, source, profile)
+func DownloadDependency(basePath string, source *latest.SourceConfig, profile string, vars []latest.DependencyVar, update bool, log log.Logger) (ID string, localPath string, err error) {
+	ID = GetDependencyID(basePath, source, profile, vars)
 
 	// Resolve source
 	if source.Git != "" {
@@ -120,7 +120,7 @@ func DownloadDependency(basePath string, source *latest.SourceConfig, profile st
 	return ID, localPath, nil
 }
 
-func GetDependencyID(basePath string, source *latest.SourceConfig, profile string) string {
+func GetDependencyID(basePath string, source *latest.SourceConfig, profile string, vars []latest.DependencyVar) string {
 	if source.Git != "" {
 		// Erase authentication credentials
 		id := strings.TrimSpace(source.Git)
@@ -142,6 +142,9 @@ func GetDependencyID(basePath string, source *latest.SourceConfig, profile strin
 		if len(source.CloneArgs) > 0 {
 			id += " - with clone args " + strings.Join(source.CloneArgs, " ")
 		}
+		for _, v := range vars {
+			id += ";" + v.Name + "=" + v.Value
+		}
 
 		return id
 	} else if source.Path != "" {
@@ -150,6 +153,9 @@ func GetDependencyID(basePath string, source *latest.SourceConfig, profile strin
 
 			if profile != "" {
 				id += " - profile " + profile
+			}
+			for _, v := range vars {
+				id += ";" + v.Name + "=" + v.Value
 			}
 
 			return id
@@ -168,6 +174,9 @@ func GetDependencyID(basePath string, source *latest.SourceConfig, profile strin
 
 		if profile != "" {
 			filePath += " - profile " + profile
+		}
+		for _, v := range vars {
+			filePath += ";" + v.Name + "=" + v.Value
 		}
 
 		return filePath

--- a/pkg/devspace/hook/hook.go
+++ b/pkg/devspace/hook/hook.go
@@ -1,10 +1,12 @@
 package hook
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/devspace-cloud/devspace/pkg/devspace/kubectl"
 	"github.com/mgutz/ansi"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/versions/latest"
@@ -17,6 +19,7 @@ const (
 	KubeContextEnv   = "DEVSPACE_HOOK_KUBE_CONTEXT"
 	KubeNamespaceEnv = "DEVSPACE_HOOK_KUBE_NAMESPACE"
 	ErrorEnv         = "DEVSPACE_HOOK_ERROR"
+	OsArgsEnv        = "DEVSPACE_HOOK_OS_ARGS"
 )
 
 // Executer executes configured commands locally
@@ -140,7 +143,13 @@ func (e *executer) Execute(when When, stage Stage, which string, context Context
 		}
 
 		// Create extra env variables
-		extraEnv := map[string]string{}
+		osArgsBytes, err := json.Marshal(os.Args)
+		if err != nil {
+			return err
+		}
+		extraEnv := map[string]string{
+			OsArgsEnv: string(osArgsBytes),
+		}
 		if context.Client != nil {
 			extraEnv[KubeContextEnv] = context.Client.CurrentContext()
 			extraEnv[KubeNamespaceEnv] = context.Client.Namespace()

--- a/pkg/devspace/hook/hook.go
+++ b/pkg/devspace/hook/hook.go
@@ -2,6 +2,7 @@ package hook
 
 import (
 	"fmt"
+	"github.com/devspace-cloud/devspace/pkg/devspace/kubectl"
 	"github.com/mgutz/ansi"
 	"io"
 	"strings"
@@ -12,9 +13,17 @@ import (
 	dockerterm "github.com/docker/docker/pkg/term"
 )
 
+const (
+	KubeContextEnv   = "DEVSPACE_HOOK_KUBE_CONTEXT"
+	KubeNamespaceEnv = "DEVSPACE_HOOK_KUBE_NAMESPACE"
+	ErrorEnv         = "DEVSPACE_HOOK_ERROR"
+)
+
 // Executer executes configured commands locally
 type Executer interface {
-	Execute(when When, stage Stage, which string, log logpkg.Logger) error
+	OnError(stage Stage, whichs []string, context Context, log logpkg.Logger)
+	Execute(when When, stage Stage, which string, context Context, log logpkg.Logger) error
+	ExecuteMultiple(when When, stage Stage, whichs []string, context Context, log logpkg.Logger) error
 }
 
 type executer struct {
@@ -36,6 +45,8 @@ const (
 	Before When = iota
 	// After is used to tell devspace to execute a hook after a certain stage
 	After
+	// OnError is used to tell devspace to execute a hook after a certain error occured
+	OnError
 )
 
 // Stage is the type that defines the stage at when to execute a hook
@@ -59,8 +70,35 @@ var (
 	_, stdout, stderr = dockerterm.StdStreams()
 )
 
+// Context holds hook context information
+type Context struct {
+	Error  error
+	Client kubectl.Client
+}
+
+// ExecuteMultiple executes multiple hooks at a specific time
+func (e *executer) ExecuteMultiple(when When, stage Stage, whichs []string, context Context, log logpkg.Logger) error {
+	for _, which := range whichs {
+		err := e.Execute(when, stage, which, context, log)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// OnError is a convience method to handle the resulting error of a hook execution. Since we mostly return anyways after
+// an error has occured this only prints additonal information why the hook failed
+func (e *executer) OnError(stage Stage, whichs []string, context Context, log logpkg.Logger) {
+	err := e.ExecuteMultiple(OnError, stage, whichs, context, log)
+	if err != nil {
+		log.Warnf("Hook failed: %v", err)
+	}
+}
+
 // Execute executes hooks at a specific time
-func (e *executer) Execute(when When, stage Stage, which string, log logpkg.Logger) error {
+func (e *executer) Execute(when When, stage Stage, which string, context Context, log logpkg.Logger) error {
 	if e.config.Hooks != nil && len(e.config.Hooks) > 0 {
 		hooksToExecute := []*latest.HookConfig{}
 
@@ -87,8 +125,28 @@ func (e *executer) Execute(when When, stage Stage, which string, log logpkg.Logg
 					} else if stage == StagePullSecrets && hook.When.After.PullSecrets != "" && strings.TrimSpace(hook.When.After.PullSecrets) == strings.TrimSpace(which) {
 						hooksToExecute = append(hooksToExecute, hook)
 					}
+				} else if when == OnError && hook.When.OnError != nil {
+					if stage == StageDeployments && hook.When.OnError.Deployments != "" && strings.TrimSpace(hook.When.OnError.Deployments) == strings.TrimSpace(which) {
+						hooksToExecute = append(hooksToExecute, hook)
+					} else if stage == StageImages && hook.When.OnError.Images != "" && strings.TrimSpace(hook.When.OnError.Images) == strings.TrimSpace(which) {
+						hooksToExecute = append(hooksToExecute, hook)
+					} else if stage == StageDependencies && hook.When.OnError.Dependencies != "" && strings.TrimSpace(hook.When.OnError.Dependencies) == strings.TrimSpace(which) {
+						hooksToExecute = append(hooksToExecute, hook)
+					} else if stage == StagePullSecrets && hook.When.OnError.PullSecrets != "" && strings.TrimSpace(hook.When.OnError.PullSecrets) == strings.TrimSpace(which) {
+						hooksToExecute = append(hooksToExecute, hook)
+					}
 				}
 			}
+		}
+
+		// Create extra env variables
+		extraEnv := map[string]string{}
+		if context.Client != nil {
+			extraEnv[KubeContextEnv] = context.Client.CurrentContext()
+			extraEnv[KubeNamespaceEnv] = context.Client.Namespace()
+		}
+		if when == OnError && context.Error != nil {
+			extraEnv[ErrorEnv] = context.Error.Error()
 		}
 
 		// Execute hooks
@@ -106,7 +164,7 @@ func (e *executer) Execute(when When, stage Stage, which string, log logpkg.Logg
 			}
 
 			log.Infof("Execute hook: %s", ansi.Color(fmt.Sprintf("%s '%s'", hook.Command, strings.Join(hook.Args, "' '")), "white+b"))
-			err := command.ExecuteCommand(hook.Command, hook.Args, writer, writer)
+			err := command.ExecuteCommandWithEnv(hook.Command, hook.Args, writer, writer, extraEnv)
 			if err != nil {
 				return err
 			}

--- a/pkg/devspace/hook/hook_test.go
+++ b/pkg/devspace/hook/hook_test.go
@@ -10,7 +10,7 @@ import (
 func TestHookWithoutExecution(t *testing.T) {
 	//Execute 0 hooks
 	executer := NewExecuter(&latest.Config{})
-	err := executer.Execute(0, 0, "", log.Discard)
+	err := executer.Execute(0, 0, "", Context{}, log.Discard)
 	if err != nil {
 		t.Fatalf("Failed to execute 0 hooks with error: %v", err)
 	}
@@ -21,7 +21,7 @@ func TestHookWithoutExecution(t *testing.T) {
 			&latest.HookConfig{},
 		},
 	})
-	err = executer.Execute(0, 0, "", log.Discard)
+	err = executer.Execute(0, 0, "", Context{}, log.Discard)
 	if err != nil {
 		t.Fatalf("Failed to execute 1 hook without when with error: %v", err)
 	}
@@ -34,7 +34,7 @@ func TestHookWithoutExecution(t *testing.T) {
 			},
 		},
 	})
-	err = executer.Execute(0, 0, "", log.Discard)
+	err = executer.Execute(0, 0, "", Context{}, log.Discard)
 	if err != nil {
 		t.Fatalf("Failed to execute 1 hook without When.Before and When.After with error: %v", err)
 	}
@@ -49,7 +49,7 @@ func TestHookWithoutExecution(t *testing.T) {
 			},
 		},
 	})
-	err = executer.Execute(Before, 0, "", log.Discard)
+	err = executer.Execute(Before, 0, "", Context{}, log.Discard)
 	if err != nil {
 		t.Fatalf("Failed to execute 1 hook with empty When.Before: %v", err)
 	}
@@ -64,7 +64,7 @@ func TestHookWithoutExecution(t *testing.T) {
 			},
 		},
 	})
-	err = executer.Execute(After, 0, "", log.Discard)
+	err = executer.Execute(After, 0, "", Context{}, log.Discard)
 	if err != nil {
 		t.Fatalf("Failed to execute 1 hook with empty When.After: %v", err)
 	}
@@ -85,7 +85,7 @@ func TestHookWithExecution(t *testing.T) {
 			},
 		},
 	})
-	err := executer.Execute(Before, StageDeployments, "theseDeployments", log.Discard)
+	err := executer.Execute(Before, StageDeployments, "theseDeployments", Context{}, log.Discard)
 	if err != nil {
 		t.Fatalf("Failed to execute 1 hook with empty When.After: %v", err)
 	}

--- a/pkg/devspace/hook/testing/hook.go
+++ b/pkg/devspace/hook/testing/hook.go
@@ -1,6 +1,6 @@
 package hook
 
-import(
+import (
 	"github.com/devspace-cloud/devspace/pkg/devspace/hook"
 	"github.com/devspace-cloud/devspace/pkg/util/log"
 )
@@ -8,7 +8,14 @@ import(
 // FakeHook is a fake implementation of the interface Hook
 type FakeHook struct{}
 
-// Execute is a fake implementation of this function
-func (f *FakeHook) Execute(when hook.When, stage hook.Stage, which string, log log.Logger) error {
+func (f *FakeHook) Execute(when hook.When, stage hook.Stage, which string, context hook.Context, log log.Logger) error {
 	return nil
+}
+
+func (f *FakeHook) ExecuteMultiple(when hook.When, stage hook.Stage, whichs []string, context hook.Context, log log.Logger) error {
+	return nil
+}
+
+func (f *FakeHook) OnError(stage hook.Stage, whichs []string, context hook.Context, log log.Logger) {
+	return
 }

--- a/pkg/devspace/server/download.go
+++ b/pkg/devspace/server/download.go
@@ -2,8 +2,10 @@ package server
 
 import (
 	"archive/tar"
+	"bytes"
 	"compress/gzip"
 	"fmt"
+	"github.com/devspace-cloud/devspace/assets"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -39,10 +41,10 @@ func downloadUI() (string, error) {
 
 	homedir, _ := homedir.Dir()
 
-	// Check if sync is already in pod
+	// Check if ui was already downloaded / extracted
 	uiFolder := filepath.Join(homedir, constants.DefaultHomeDevSpaceFolder, UITempFolder, version)
 
-	// Download sync helper if necessary
+	// Download / extract if necessary
 	err := downloadUITar(uiFolder, version)
 	if err != nil {
 		return "", errors.Wrap(err, "download ui tar ball")
@@ -52,7 +54,7 @@ func downloadUI() (string, error) {
 }
 
 func downloadUITar(uiFolder, version string) error {
-	// Check if folder exists
+	// Check if file exists
 	_, err := os.Stat(filepath.Join(uiFolder, "index.html"))
 	if err == nil {
 		return nil
@@ -69,6 +71,11 @@ func downloadUITar(uiFolder, version string) error {
 }
 
 func downloadFile(version string, folder string) error {
+	uiBytes, err := assets.Asset("release/ui.tar.gz")
+	if err == nil {
+		return untar(bytes.NewReader(uiBytes), folder)
+	}
+
 	// Create download url
 	url := ""
 	if version == "latest" {


### PR DESCRIPTION
### Changes
- Adds `dependencies.*.vars` to override variables in dependencies
- Adds `images.*.build.kaniko.nodeSelector`, `images.*.build.kaniko.initImage` and `images.*.build.kaniko.serviceAccount`
- Compiles the sync helper binary and ui archive into the devspace binary
- Fixes an issue in dependencies where loading a config with variables from a relative local path command could result in an error
- Adds `onError` for hooks 
- Adds environment variables to hook execution for more context information within hooks