### PR TITLE
feat: add selection flags to devspace restart

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -68,8 +68,8 @@ devspace sync --container-path=/my-path
 		},
 	}
 
-	syncCmd.Flags().StringVarP(&cmd.Container, "container", "c", "", "Container name within pod where to execute command")
-	syncCmd.Flags().StringVar(&cmd.Pod, "pod", "", "Pod to open a shell to")
+	syncCmd.Flags().StringVarP(&cmd.Container, "container", "c", "", "Container name within pod where to sync to")
+	syncCmd.Flags().StringVar(&cmd.Pod, "pod", "", "Pod to sync to")
 	syncCmd.Flags().StringVarP(&cmd.LabelSelector, "label-selector", "l", "", "Comma separated key=value selector list (e.g. release=test)")
 	syncCmd.Flags().BoolVar(&cmd.Pick, "pick", false, "Select a pod")
 

--- a/pkg/devspace/build/builder/helper/util.go
+++ b/pkg/devspace/build/builder/helper/util.go
@@ -123,7 +123,7 @@ func RewriteDockerfile(dockerfile string, entrypoint []string, cmd []string, add
 			return "", err
 		}
 
-		oldEntrypoint, oldCmd, err := getLastestEntrypointAndCmd(string(data), target)
+		oldEntrypoint, oldCmd, err := GetEntrypointAndCmd(string(data), target)
 		if err != nil {
 			return "", err
 		}
@@ -203,8 +203,12 @@ func GetDockerfileTargets(dockerfile string) ([]string, error) {
 	}
 
 	rawTargets := targetFinder.FindAllStringSubmatch(content, -1)
-
 	for _, target := range rawTargets {
+		entrypoint, cmd, err := GetEntrypointAndCmd(content, target[3])
+		if err != nil || (len(entrypoint) == 0 && len(cmd) == 0) {
+			continue
+		}
+
 		targets = append(targets, target[3])
 	}
 
@@ -267,7 +271,7 @@ func splitDockerfileAtTarget(content string, target string) (string, string, err
 var entrypointLinePattern = regexp.MustCompile(`(?i)^[\s]*ENTRYPOINT[\s]+(.+)$`)
 var cmdLinePattern = regexp.MustCompile(`(?i)^[\s]*CMD[\s]+(.+)$`)
 
-func getLastestEntrypointAndCmd(content string, target string) ([]string, []string, error) {
+func GetEntrypointAndCmd(content string, target string) ([]string, []string, error) {
 	if target == "" {
 		return parseLastOccurence(content)
 	}

--- a/pkg/devspace/services/attach.go
+++ b/pkg/devspace/services/attach.go
@@ -12,7 +12,7 @@ import (
 
 // StartAttach opens a new terminal
 func (serviceClient *client) StartAttach(imageSelector []string, interrupt chan error) error {
-	targetSelector, err := targetselector.NewTargetSelector(serviceClient.config, serviceClient.client, serviceClient.selectorParameter, true, imageSelector)
+	targetSelector, err := targetselector.NewTargetSelector(serviceClient.client, serviceClient.selectorParameter, true, imageSelector)
 	if err != nil {
 		return err
 	}

--- a/pkg/devspace/services/logs.go
+++ b/pkg/devspace/services/logs.go
@@ -16,7 +16,7 @@ func (serviceClient *client) StartLogs(imageSelector []string, follow bool, tail
 
 // StartLogsWithWriter prints the logs and then attaches to the container with the given stdout and stderr
 func (serviceClient *client) StartLogsWithWriter(imageSelector []string, follow bool, tail int64, writer io.Writer) error {
-	targetSelector, err := targetselector.NewTargetSelector(serviceClient.config, serviceClient.client, serviceClient.selectorParameter, true, imageSelector)
+	targetSelector, err := targetselector.NewTargetSelector(serviceClient.client, serviceClient.selectorParameter, true, imageSelector)
 	if err != nil {
 		return err
 	}

--- a/pkg/devspace/services/port_forwarding.go
+++ b/pkg/devspace/services/port_forwarding.go
@@ -34,7 +34,7 @@ func (serviceClient *client) StartPortForwarding(interrupt chan error) error {
 }
 
 func (serviceClient *client) startForwarding(portForwarding *latest.PortForwardingConfig, interrupt chan error, log logpkg.Logger) error {
-	selector, err := targetselector.NewTargetSelector(serviceClient.config, serviceClient.client, &targetselector.SelectorParameter{
+	selector, err := targetselector.NewTargetSelector(serviceClient.client, &targetselector.SelectorParameter{
 		ConfigParameter: targetselector.ConfigParameter{
 			Namespace:     portForwarding.Namespace,
 			LabelSelector: portForwarding.LabelSelector,

--- a/pkg/devspace/services/reverse_port_forwarding.go
+++ b/pkg/devspace/services/reverse_port_forwarding.go
@@ -33,7 +33,7 @@ func (serviceClient *client) StartReversePortForwarding(interrupt chan error) er
 }
 
 func (serviceClient *client) startReversePortForwarding(portForwarding *latest.PortForwardingConfig, interrupt chan error, log logpkg.Logger) error {
-	selector, err := targetselector.NewTargetSelector(serviceClient.config, serviceClient.client, &targetselector.SelectorParameter{
+	selector, err := targetselector.NewTargetSelector(serviceClient.client, &targetselector.SelectorParameter{
 		ConfigParameter: targetselector.ConfigParameter{
 			Namespace:     portForwarding.Namespace,
 			LabelSelector: portForwarding.LabelSelector,

--- a/pkg/devspace/services/sync.go
+++ b/pkg/devspace/services/sync.go
@@ -157,7 +157,7 @@ func (serviceClient *client) startSyncClient(options *startClientOptions, log lo
 		}
 	}
 
-	selector, err := targetselector.NewTargetSelector(serviceClient.config, serviceClient.client, options.SelectorParameter, options.AllowPodPick, targetselector.ImageSelectorFromConfig(syncConfig.ImageName, serviceClient.config, serviceClient.generated))
+	selector, err := targetselector.NewTargetSelector(serviceClient.client, options.SelectorParameter, options.AllowPodPick, targetselector.ImageSelectorFromConfig(syncConfig.ImageName, serviceClient.config, serviceClient.generated))
 	if err != nil {
 		return errors.Errorf("Error creating target selector: %v", err)
 	}

--- a/pkg/devspace/services/targetselector/selector_parameter.go
+++ b/pkg/devspace/services/targetselector/selector_parameter.go
@@ -3,7 +3,6 @@ package targetselector
 import (
 	"strings"
 
-	"github.com/devspace-cloud/devspace/pkg/devspace/config/versions/latest"
 	"github.com/devspace-cloud/devspace/pkg/devspace/kubectl"
 )
 
@@ -31,7 +30,7 @@ type ConfigParameter struct {
 }
 
 // GetNamespace retrieves the target namespace
-func (t *SelectorParameter) GetNamespace(config *latest.Config, kubeClient kubectl.Client) (string, error) {
+func (t *SelectorParameter) GetNamespace(kubeClient kubectl.Client) (string, error) {
 	if t.CmdParameter.Namespace != "" {
 		return t.CmdParameter.Namespace, nil
 	}
@@ -43,7 +42,7 @@ func (t *SelectorParameter) GetNamespace(config *latest.Config, kubeClient kubec
 }
 
 // GetLabelSelector retrieves the label selector of the target
-func (t *SelectorParameter) GetLabelSelector(config *latest.Config) (string, error) {
+func (t *SelectorParameter) GetLabelSelector() (string, error) {
 	if t.CmdParameter.LabelSelector != "" {
 		return t.CmdParameter.LabelSelector, nil
 	}

--- a/pkg/devspace/services/targetselector/target_selector.go
+++ b/pkg/devspace/services/targetselector/target_selector.go
@@ -43,19 +43,18 @@ type TargetSelector struct {
 	allowPick bool
 
 	kubeClient kubectl.Client
-	config     *latest.Config
 }
 
 // NewTargetSelector creates a new target selector for selecting a target pod or container
-func NewTargetSelector(config *latest.Config, kubeClient kubectl.Client, sp *SelectorParameter, allowPick bool, imageSelector []string) (*TargetSelector, error) {
+func NewTargetSelector(kubeClient kubectl.Client, sp *SelectorParameter, allowPick bool, imageSelector []string) (*TargetSelector, error) {
 	// Get namespace
-	namespace, err := sp.GetNamespace(config, kubeClient)
+	namespace, err := sp.GetNamespace(kubeClient)
 	if err != nil {
 		return nil, err
 	}
 
 	// Get label selector
-	labelSelector, err := sp.GetLabelSelector(config)
+	labelSelector, err := sp.GetLabelSelector()
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +72,6 @@ func NewTargetSelector(config *latest.Config, kubeClient kubectl.Client, sp *Sel
 
 		kubeClient: kubeClient,
 		allowPick:  allowPick,
-		config:     config,
 	}, nil
 }
 

--- a/pkg/devspace/services/terminal.go
+++ b/pkg/devspace/services/terminal.go
@@ -15,7 +15,7 @@ import (
 func (serviceClient *client) StartTerminal(args []string, imageSelector []string, interrupt chan error, wait bool) (int, error) {
 	command := serviceClient.getCommand(args)
 
-	targetSelector, err := targetselector.NewTargetSelector(serviceClient.config, serviceClient.client, serviceClient.selectorParameter, true, imageSelector)
+	targetSelector, err := targetselector.NewTargetSelector(serviceClient.client, serviceClient.selectorParameter, true, imageSelector)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
### Changes
- add selection flags for `devspace restart`
- fixes an issue where the restart helper was configured during `devspace init` even if there were not ENTRYPOINT or CMD in the Dockerfile