### PR TITLE
RestartHelperPath, rebuild detection fix & build pod annoations / labels

### DIFF
--- a/pkg/devspace/build/builder/docker/docker.go
+++ b/pkg/devspace/build/builder/docker/docker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"github.com/devspace-cloud/devspace/pkg/devspace/build/builder/restart"
 	"io"
 	"os"
 	"path/filepath"
@@ -204,7 +205,12 @@ func (b *Builder) BuildImage(contextPath, dockerfilePath string, entrypoint []st
 
 		// inject the build script
 		if b.helper.ImageConf.InjectRestartHelper {
-			buildCtx, err = helper.InjectBuildScriptInContext(buildCtx)
+			helperScript, err := restart.LoadRestartHelper(b.helper.ImageConf.RestartHelperPath)
+			if err != nil {
+				return errors.Wrap(err, "load restart helper")
+			}
+
+			buildCtx, err = helper.InjectBuildScriptInContext(helperScript, buildCtx)
 			if err != nil {
 				return errors.Wrap(err, "inject build script into context")
 			}

--- a/pkg/devspace/build/builder/helper/helper.go
+++ b/pkg/devspace/build/builder/helper/helper.go
@@ -167,6 +167,8 @@ func (b *BuildHelper) ShouldRebuild(cache *generated.CacheConfig, forceRebuild, 
 				}
 			}
 		}
+	} else {
+		ignoreContextPathChanges = false
 	}
 
 	// Okay this check verifies if the previous deploy context was local kubernetes context where we didn't push the image and now have a kubernetes context where we probably push

--- a/pkg/devspace/build/builder/helper/util.go
+++ b/pkg/devspace/build/builder/helper/util.go
@@ -49,7 +49,7 @@ func GetDockerfileAndContext(imageConf *latest.ImageConfig) (string, string) {
 }
 
 // InjectBuildScriptInContext will add the restart helper script to the build context
-func InjectBuildScriptInContext(buildCtx io.ReadCloser) (io.ReadCloser, error) {
+func InjectBuildScriptInContext(helperScript string, buildCtx io.ReadCloser) (io.ReadCloser, error) {
 	now := time.Now()
 	hdrTmpl := &tar.Header{
 		Mode:       0777,
@@ -74,7 +74,7 @@ func InjectBuildScriptInContext(buildCtx io.ReadCloser) (io.ReadCloser, error) {
 			return fldTmpl, nil, nil
 		},
 		restart.ScriptContextPath: func(_ string, h *tar.Header, content io.Reader) (*tar.Header, []byte, error) {
-			return hdrTmpl, []byte(restart.HelperScript), nil
+			return hdrTmpl, []byte(helperScript), nil
 		},
 	})
 	return buildCtx, nil

--- a/pkg/devspace/build/builder/kaniko/build_pod.go
+++ b/pkg/devspace/build/builder/kaniko/build_pod.go
@@ -209,6 +209,7 @@ func (b *Builder) getBuildPod(buildID string, options *types.ImageBuildOptions, 
 	pod := &k8sv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "devspace-build-",
+			Annotations:  map[string]string{},
 			Labels: map[string]string{
 				"devspace-build":    "true",
 				"devspace-build-id": buildID,
@@ -244,6 +245,16 @@ func (b *Builder) getBuildPod(buildID string, options *types.ImageBuildOptions, 
 			Volumes:            volumes,
 			RestartPolicy:      k8sv1.RestartPolicyNever,
 		},
+	}
+
+	// add extra annotations
+	for k, v := range kanikoOptions.Annotations {
+		pod.Annotations[k] = v
+	}
+
+	// add extra labels
+	for k, v := range kanikoOptions.Labels {
+		pod.Labels[k] = v
 	}
 
 	// check if we have specific options for the resources part

--- a/pkg/devspace/build/builder/kaniko/kaniko.go
+++ b/pkg/devspace/build/builder/kaniko/kaniko.go
@@ -262,7 +262,12 @@ func (b *Builder) BuildImage(contextPath, dockerfilePath string, entrypoint []st
 
 			scriptPath := filepath.Join(tempDir, restart.ScriptName)
 			remoteFolder := filepath.ToSlash(filepath.Join(kanikoContextPath, ".devspace", ".devspace"))
-			err = ioutil.WriteFile(scriptPath, []byte(restart.HelperScript), 0777)
+			helperScript, err := restart.LoadRestartHelper(b.helper.ImageConf.RestartHelperPath)
+			if err != nil {
+				return errors.Wrap(err, "load restart helper")
+			}
+
+			err = ioutil.WriteFile(scriptPath, []byte(helperScript), 0777)
 			if err != nil {
 				return errors.Wrap(err, "write restart helper script")
 			}

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -86,6 +86,10 @@ type ImageConfig struct {
 	// dockerfile for this image, otherwise devspace will fail.
 	InjectRestartHelper bool `yaml:"injectRestartHelper,omitempty" json:"injectRestartHelper,omitempty"`
 
+	// If specified DevSpace will load the restart helper from this location instead of using the bundled
+	// one within DevSpace. Can be either a local path or an URL where to find the restart helper.
+	RestartHelperPath string `yaml:"restartHelperPath,omitempty" json:"restartHelperPath,omitempty"`
+
 	// These instructions will be appended to the Dockerfile that is build at the current build target
 	// and are appended before the entrypoint and cmd instructions
 	AppendDockerfileInstructions []string `yaml:"appendDockerfileInstructions,omitempty" json:"appendDockerfileInstructions,omitempty"`

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -154,6 +154,12 @@ type KanikoConfig struct {
 	// the service account to use for the kaniko pod
 	ServiceAccount string `yaml:"serviceAccount,omitempty" json:"serviceAccount,omitempty"`
 
+	// extra annotations that will be added to the build pod
+	Annotations map[string]string `yaml:"annotations,omitempty" json:"annotations,omitempty"`
+
+	// extra labels that will be added to the build pod
+	Labels map[string]string `yaml:"labels,omitempty" json:"labels,omitempty"`
+
 	// additional mounts that will be added to the build pod
 	AdditionalMounts []KanikoAdditionalMount `yaml:"additionalMounts,omitempty" json:"additionalMounts,omitempty"`
 

--- a/pkg/devspace/services/log_manager.go
+++ b/pkg/devspace/services/log_manager.go
@@ -105,7 +105,7 @@ func (l *logManager) Start() error {
 			namespace, pod, container := splitted[0], splitted[1], splitted[2]
 
 			logsContext, cancel := context.WithCancel(context.Background())
-			logsLog := log.NewDefaultPrefixLogger("["+t.name+"] ", l.output)
+			logsLog := log.NewPrefixLogger("["+t.name+"] ", log.Colors[(len(log.Colors)-1)-(len(l.activeLogs)%len(log.Colors))], l.output)
 			go func() {
 				logsLog.Infof("Start streaming logs for %s", t.key)
 				reader, err := l.client.Logs(logsContext, namespace, pod, container, false, &l.tail, true)


### PR DESCRIPTION
### Changes
- Adds `images.*.restartHelperPath`
- Fixes an issue in rebuild detection
- Adds labels & annotations for kaniko build pod