### PR TITLE
fix: fixes a windows terminal issue

### DIFF
--- a/pkg/util/terminal/tty.go
+++ b/pkg/util/terminal/tty.go
@@ -1,7 +1,7 @@
 package terminal
 
 import (
-	dockerterm "github.com/docker/docker/pkg/term"
+	dockerterm "github.com/moby/term"
 	"io"
 	"k8s.io/kubectl/pkg/util/term"
 )


### PR DESCRIPTION
## Changes
- Fixed an issue where CTRL+C would terminate devspace terminal on older windows versions