### PR TITLE
devspace analyze add IgnorePodRestarts flags

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -14,9 +14,10 @@ import (
 type AnalyzeCmd struct {
 	*flags.GlobalFlags
 
-	Wait    bool
-	Patient bool
-	Timeout int
+	Wait              bool
+	Patient           bool
+	Timeout           int
+	IgnorePodRestarts bool
 }
 
 // NewAnalyzeCmd creates a new analyze command
@@ -47,6 +48,7 @@ devspace analyze --namespace=mynamespace
 	analyzeCmd.Flags().BoolVar(&cmd.Wait, "wait", true, "Wait for pods to get ready if they are just starting")
 	analyzeCmd.Flags().IntVar(&cmd.Timeout, "timeout", 120, "Timeout until analyze should stop waiting")
 	analyzeCmd.Flags().BoolVar(&cmd.Patient, "patient", false, "If true, analyze will ignore failing pods and events until every deployment, statefulset, replicaset and pods are ready or the timeout is reached")
+	analyzeCmd.Flags().BoolVar(&cmd.IgnorePodRestarts, "ignore-pod-restarts", false, "If true, analyze will ignore the restart events of running pods")
 
 	return analyzeCmd
 }
@@ -101,9 +103,10 @@ func (cmd *AnalyzeCmd) RunAnalyze(f factory.Factory, plugins []plugin.Metadata, 
 	}
 
 	err = analyze.NewAnalyzer(client, log).Analyze(namespace, analyze.Options{
-		Wait:    cmd.Wait,
-		Timeout: cmd.Timeout,
-		Patient: cmd.Patient,
+		Wait:              cmd.Wait,
+		Timeout:           cmd.Timeout,
+		Patient:           cmd.Patient,
+		IgnorePodRestarts: cmd.IgnorePodRestarts,
 	})
 	if err != nil {
 		return errors.Wrap(err, "analyze")

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b
 	github.com/miekg/pkcs11 v1.0.3 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/moby/term v0.0.0-20200312100748-672ec06f55cd
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/opencontainers/runc v0.1.1 // indirect

--- a/pkg/devspace/analyze/pods.go
+++ b/pkg/devspace/analyze/pods.go
@@ -237,6 +237,14 @@ func getContainerProblem(client kubectl.Client, pod *v1.Pod, containerStatus *v1
 			containerProblem.Waiting = true
 			containerProblem.Reason = containerStatus.State.Waiting.Reason
 			containerProblem.Message = containerStatus.State.Waiting.Message
+
+			// when containerStatus=Waiting && RestartCount>0, print LastFaultyExecutionLog
+			if containerStatus.RestartCount > 0 {
+				containerProblem.LastExitCode = int(containerStatus.LastTerminationState.Terminated.ExitCode)
+				if containerProblem.LastExitCode != 0 {
+					containerProblem.LastFaultyExecutionLog, _ = client.ReadLogs(pod.Namespace, pod.Name, containerStatus.Name, true, &tailLines)
+				}
+			}
 		}
 	}
 

--- a/pkg/devspace/analyze/pods.go
+++ b/pkg/devspace/analyze/pods.go
@@ -242,7 +242,7 @@ func getContainerProblem(client kubectl.Client, pod *v1.Pod, containerStatus *v1
 			if containerStatus.RestartCount > 0 {
 				containerProblem.LastExitCode = int(containerStatus.LastTerminationState.Terminated.ExitCode)
 				if containerProblem.LastExitCode != 0 {
-					containerProblem.LastFaultyExecutionLog, _ = client.ReadLogs(pod.Namespace, pod.Name, containerStatus.Name, true, &tailLines)
+					containerProblem.LastFaultyExecutionLog, _ = client.ReadLogs(pod.Namespace, pod.Name, containerStatus.Name, false, &tailLines)
 				}
 			}
 		}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others)  
/kind enhancement


**What is this pull request for? Which issues does it resolve?** (use `resolves #<issue_number>` if possible)  
resolves #
`devspace analyze` add `IgnorePodRestarts` flags:
`Usage:
  devspace analyze [flags]

Flags:
      --ignore-pod-restarts   If true, analyze will ignore the restart events of running pods`

**Does this pull request has user-facing changes?** (e.g. config changes, new/modified commands, new/modified flags)  
new flags

**Does this pull request add new dependencies?**  
no

**What else do we need to know?**  
Sometimes pod startup successfully after a couples of restarts.  `devspace analyze` cmd prints LastFaultyExecutionLog for this situation. The new flag `IgnorePodRestarts` will provide a choice to  ignore the restart events of running pods.

