### PR TITLE
DEVSPACE_VERSION, purge hooks & sync fix

### DIFF
--- a/cmd/dev.go
+++ b/cmd/dev.go
@@ -61,8 +61,9 @@ type DevCmd struct {
 
 	UI bool
 
-	Terminal    bool
-	Interactive bool
+	Terminal         bool
+	WorkingDirectory string
+	Interactive      bool
 
 	Wait    bool
 	Timeout int
@@ -132,6 +133,7 @@ Open terminal instead of logs:
 	devCmd.Flags().BoolVar(&cmd.ExitAfterDeploy, "exit-after-deploy", false, "Exits the command after building the images and deploying the project")
 	devCmd.Flags().BoolVarP(&cmd.Interactive, "interactive", "i", false, "Enable interactive mode for images (overrides entrypoint with sleep command) and start terminal proxy")
 	devCmd.Flags().BoolVarP(&cmd.Terminal, "terminal", "t", false, "Open a terminal instead of showing logs")
+	devCmd.Flags().StringVar(&cmd.WorkingDirectory, "workdir", "", "The working directory where to open the terminal or execute the command")
 
 	devCmd.Flags().BoolVar(&cmd.Wait, "wait", false, "If true will wait first for pods to be running or fails after given timeout")
 	devCmd.Flags().IntVar(&cmd.Timeout, "timeout", 120, "Timeout until dev should stop waiting and fail")
@@ -519,7 +521,7 @@ func (cmd *DevCmd) startOutput(interactiveMode bool, config *latest.Config, gene
 			}
 
 			selectorOptions.ImageSelector = imageSelector
-			return servicesClient.StartTerminal(selectorOptions, args, exitChan, true)
+			return servicesClient.StartTerminal(selectorOptions, args, cmd.WorkingDirectory, exitChan, true)
 		} else if config.Dev == nil || config.Dev.Logs == nil || config.Dev.Logs.Disabled == nil || *config.Dev.Logs.Disabled == false {
 			// Log multiple images at once
 			manager, err := services.NewLogManager(client, config, generatedConfig, exitChan, logger)

--- a/cmd/enter.go
+++ b/cmd/enter.go
@@ -21,6 +21,8 @@ type EnterCmd struct {
 	Pod           string
 	Pick          bool
 	Wait          bool
+
+	WorkingDirectory string
 }
 
 // NewEnterCmd creates a new enter command
@@ -53,6 +55,7 @@ devspace enter bash -l release=test
 	enterCmd.Flags().StringVar(&cmd.Pod, "pod", "", "Pod to open a shell to")
 	enterCmd.Flags().StringVar(&cmd.Image, "image", "", "Image is the config name of an image to select in the devspace config (e.g. 'default'), it is NOT a docker image like myuser/myimage")
 	enterCmd.Flags().StringVarP(&cmd.LabelSelector, "label-selector", "l", "", "Comma separated key=value selector list (e.g. release=test)")
+	enterCmd.Flags().StringVar(&cmd.WorkingDirectory, "workdir", "", "The working directory where to open the terminal or execute the command")
 
 	enterCmd.Flags().BoolVar(&cmd.Pick, "pick", true, "Select a pod / container if multiple are found")
 	enterCmd.Flags().BoolVar(&cmd.Wait, "wait", false, "Wait for the pod(s) to start if they are not running")
@@ -115,7 +118,7 @@ func (cmd *EnterCmd) Run(f factory.Factory, plugins []plugin.Metadata, cobraCmd 
 	selectorOptions.ImageSelector = imageSelector
 
 	// Start terminal
-	exitCode, err := f.NewServicesClient(nil, generatedConfig, client, logger).StartTerminal(selectorOptions, args, make(chan error), cmd.Wait)
+	exitCode, err := f.NewServicesClient(nil, generatedConfig, client, logger).StartTerminal(selectorOptions, args, cmd.WorkingDirectory, make(chan error), cmd.Wait)
 	if err != nil {
 		return err
 	} else if exitCode != 0 {

--- a/examples/quickstart/.dockerignore
+++ b/examples/quickstart/.dockerignore
@@ -2,3 +2,5 @@ Dockerfile
 .devspace/
 chart/
 node_modules/
+test/
+devspace.yaml

--- a/pkg/devspace/config/loader/predefined_vars.go
+++ b/pkg/devspace/config/loader/predefined_vars.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/devspace-cloud/devspace/pkg/devspace/kubectl/util"
+	"github.com/devspace-cloud/devspace/pkg/devspace/upgrade"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -18,6 +19,9 @@ import (
 
 // predefinedVars holds all predefined variables that can be used in the config
 var predefinedVars = map[string]func(loader *configLoader) (string, error){
+	"DEVSPACE_VERSION": func(loader *configLoader) (string, error) {
+		return upgrade.GetVersion(), nil
+	},
 	"DEVSPACE_RANDOM": func(loader *configLoader) (string, error) {
 		return randutil.GenerateRandomString(6), nil
 	},

--- a/pkg/devspace/config/loader/validate.go
+++ b/pkg/devspace/config/loader/validate.go
@@ -63,8 +63,27 @@ func validate(config *latest.Config) error {
 	}
 
 	for index, hookConfig := range config.Hooks {
-		if hookConfig.Command == "" {
-			return errors.Errorf("hooks[%d].command is required", index)
+		if hookConfig.Command == "" && hookConfig.Upload == nil && hookConfig.Download == nil {
+			return errors.Errorf("hooks[%d].command, hooks[%d].download or hooks[%d].upload is required", index, index, index)
+		}
+		enabled := 0
+		if hookConfig.Command != "" {
+			enabled++
+		}
+		if hookConfig.Download != nil {
+			enabled++
+		}
+		if hookConfig.Upload != nil {
+			enabled++
+		}
+		if enabled > 1 {
+			return errors.Errorf("you can only use one of hooks[%d].command, hooks[%d].upload and hooks[%d].download per hook", index, index, index)
+		}
+		if hookConfig.Upload != nil && hookConfig.Where.Container == nil {
+			return errors.Errorf("hooks[%d].where.container is required if hooks[%d].upload is used", index, index)
+		}
+		if hookConfig.Download != nil && hookConfig.Where.Container == nil {
+			return errors.Errorf("hooks[%d].where.container is required if hooks[%d].download is used", index, index)
 		}
 	}
 

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -691,6 +691,7 @@ type TerminalConfig struct {
 	ContainerName string            `yaml:"containerName,omitempty" json:"containerName,omitempty"`
 	Namespace     string            `yaml:"namespace,omitempty" json:"namespace,omitempty"`
 	Command       []string          `yaml:"command,omitempty" json:"command,omitempty"`
+	WorkDir       string            `yaml:"workDir,omitempty" json:"workDir,omitempty"`
 }
 
 // DependencyConfig defines the devspace dependency

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -767,10 +767,11 @@ type HookWhenConfig struct {
 
 // HookWhenAtConfig defines at which stage the hook should be executed
 type HookWhenAtConfig struct {
-	Images       string `yaml:"images,omitempty" json:"images,omitempty"`
-	Deployments  string `yaml:"deployments,omitempty" json:"deployments,omitempty"`
-	Dependencies string `yaml:"dependencies,omitempty" json:"dependencies,omitempty"`
-	PullSecrets  string `yaml:"pullSecrets,omitempty" json:"pullSecrets,omitempty"`
+	Images           string `yaml:"images,omitempty" json:"images,omitempty"`
+	PurgeDeployments string `yaml:"purgeDeployments,omitempty" json:"purgeDeployments,omitempty"`
+	Deployments      string `yaml:"deployments,omitempty" json:"deployments,omitempty"`
+	Dependencies     string `yaml:"dependencies,omitempty" json:"dependencies,omitempty"`
+	PullSecrets      string `yaml:"pullSecrets,omitempty" json:"pullSecrets,omitempty"`
 }
 
 // CommandConfig defines the command specification

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -731,15 +731,24 @@ type SourceConfig struct {
 
 // HookConfig defines a hook
 type HookConfig struct {
-	Command         string   `yaml:"command" json:"command"`
-	Args            []string `yaml:"args,omitempty" json:"args,omitempty"`
-	OperatingSystem string   `yaml:"os,omitempty" json:"os,omitempty"`
+	Command  string          `yaml:"command" json:"command"`
+	Args     []string        `yaml:"args,omitempty" json:"args,omitempty"`
+	Upload   *HookSyncConfig `yaml:"upload,omitempty" json:"upload,omitempty"`
+	Download *HookSyncConfig `yaml:"download,omitempty" json:"download,omitempty"`
+
+	OperatingSystem string `yaml:"os,omitempty" json:"os,omitempty"`
 
 	Background bool `yaml:"background,omitempty" json:"background,omitempty"`
 	Silent     bool `yaml:"silent,omitempty" json:"silent,omitempty"`
 
 	Where HookWhereConfig `yaml:"where,omitempty" json:"where,omitempty"`
 	When  *HookWhenConfig `yaml:"when,omitempty" json:"when,omitempty"`
+}
+
+// HookSyncConfig defines a hook upload config
+type HookSyncConfig struct {
+	LocalPath     string `yaml:"localPath,omitempty" json:"localPath,omitempty"`
+	ContainerPath string `yaml:"containerPath,omitempty" json:"containerPath,omitempty"`
 }
 
 // HookWhereConfig defines where to execute the hook

--- a/pkg/devspace/services/client.go
+++ b/pkg/devspace/services/client.go
@@ -22,7 +22,7 @@ type Client interface {
 	StartSync(interrupt chan error, printSyncLog bool, verboseSync bool) error
 
 	StartSyncFromCmd(options targetselector.Options, syncConfig *latest.SyncConfig, interrupt chan error, verbose bool) error
-	StartTerminal(options targetselector.Options, args []string, interrupt chan error, wait bool) (int, error)
+	StartTerminal(options targetselector.Options, args []string, workDir string, interrupt chan error, wait bool) (int, error)
 }
 
 type client struct {

--- a/pkg/devspace/services/terminal_test.go
+++ b/pkg/devspace/services/terminal_test.go
@@ -20,12 +20,12 @@ func TestGetCommand(t *testing.T) {
 			},
 		},
 	}
-	command := client.getCommand([]string{"args"})
+	command := client.getCommand([]string{"args"}, "")
 	assert.Equal(t, 1, len(command), "Returned command has wrong length")
 	assert.Equal(t, "args", command[0], "Wrong command returned")
 
 	client.config = &latest.Config{}
-	command = client.getCommand([]string{})
+	command = client.getCommand([]string{}, "")
 	assert.Equal(t, 3, len(command), "Returned command has wrong length")
 	assert.Equal(t, "sh", command[0], "Wrong command returned")
 	assert.Equal(t, "-c", command[1], "Wrong command returned")

--- a/pkg/devspace/sync/sync.go
+++ b/pkg/devspace/sync/sync.go
@@ -331,7 +331,10 @@ func (s *Sync) sendChangesToUpstream(changes []*FileInformation, remove bool) {
 		// We do this out of the fileIndex lock, because otherwise this could cause a deadlock
 		// (Upstream waits in getfileInformationFromEvent and upstream.events buffer is full)
 		for i := 0; i < len(sendBatch); i++ {
+			s.upstream.isBusyMutex.Lock()
+			s.upstream.isBusy = true
 			s.upstream.events <- sendBatch[i]
+			s.upstream.isBusyMutex.Unlock()
 		}
 	}
 }

--- a/pkg/devspace/sync/upstream.go
+++ b/pkg/devspace/sync/upstream.go
@@ -95,9 +95,6 @@ func (u *upstream) mainLoop() error {
 			case <-u.interrupt:
 				return nil
 			case event, ok := <-u.events:
-				u.isBusyMutex.Lock()
-				u.isBusy = true
-				u.isBusyMutex.Unlock()
 				if ok == false {
 					return nil
 				}
@@ -133,9 +130,11 @@ func (u *upstream) mainLoop() error {
 			}
 
 			changeAmount = len(changes)
-			if changeAmount == 0 {
+			if changeAmount == 0 && len(u.events) == 0 {
 				u.isBusyMutex.Lock()
-				u.isBusy = false
+				if len(u.events) == 0 {
+					u.isBusy = false
+				}
 				u.isBusyMutex.Unlock()
 			}
 		}


### PR DESCRIPTION
### Changes
- New options `upload` and `download` for hooks to upload or download files from a container:
```yaml
hooks:
# Upload the complete local bin folder to the container path ./bin
- upload:
    localPath: bin
    containerPath: bin
  where:
    container:
      imageName: default
  when:
    after:
      deployments: deployment-1
# Download a single file from the container to the local path
- download:
    localPath: build/artifact.jar
    containerPath: build/artifact-test.jar
  where:
    container:
      imageName: java
  when:
    after:
      deployments: deployment-2
```
- New predefined variable `${DEVSPACE_VERSION}`
- New options `hooks.when.before.purgeDeployments`, `hooks.when.after.purgeDeployments` and`hooks.when.onError.purgeDeployments` to execute hooks on `devspace purge`
- New option `dev.interactive.terminal.workDir` to specify a working directory to open the terminal in
- New flag `--workdir` for `devspace enter` and `devspace dev` to specify a working directory to open the terminal in or execute an command in
- Fixes an issue where the namespace was wrong when executing devspace within a cluster
- Fixes a potential race during initial sync upload