### PR TITLE
Global flags, sync exclude & in cluster kube context fix

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -87,8 +87,14 @@ func (cmd *BuildCmd) Run(f factory.Factory, plugins []plugin.Metadata, cobraCmd 
 		return err
 	}
 
+	// create kubectl client
+	client, err := f.NewKubeClientFromContext(cmd.KubeContext, cmd.Namespace, cmd.SwitchContext)
+	if err != nil {
+		log.Warnf("Unable to create new kubectl client: %v", err)
+	}
+
 	// Get the config
-	config, err := configLoader.Load()
+	config, err := configLoader.RestoreLoadSave(client)
 	if err != nil {
 		return err
 	}
@@ -104,12 +110,6 @@ func (cmd *BuildCmd) Run(f factory.Factory, plugins []plugin.Metadata, cobraCmd 
 		for _, imageConfig := range config.Images {
 			imageConfig.Tags = cmd.Tags
 		}
-	}
-
-	// create kubectl client
-	client, err := f.NewKubeClientFromContext(cmd.KubeContext, cmd.Namespace, cmd.SwitchContext)
-	if err != nil {
-		log.Warnf("Unable to create new kubectl client: %v", err)
 	}
 
 	// Create Dependencymanager

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"context"
-	"github.com/devspace-cloud/devspace/cmd/restore"
-	"github.com/devspace-cloud/devspace/cmd/save"
 	"github.com/devspace-cloud/devspace/pkg/devspace/plugin"
 	"github.com/devspace-cloud/devspace/pkg/devspace/upgrade"
 	"strconv"
@@ -99,9 +97,6 @@ devspace deploy --kube-context=deploy-context
 	deployCmd.Flags().BoolVar(&cmd.Wait, "wait", false, "If true will wait for pods to be running or fails after given timeout")
 	deployCmd.Flags().IntVar(&cmd.Timeout, "timeout", 120, "Timeout until deploy should stop waiting")
 
-	deployCmd.Flags().BoolVar(&cmd.RestoreVars, "restore-vars", false, "If true will restore the variables from kubernetes before loading the config")
-	deployCmd.Flags().BoolVar(&cmd.SaveVars, "save-vars", false, "If true will save the variables to kubernetes after loading the config")
-	deployCmd.Flags().StringVar(&cmd.VarsSecretName, "vars-secret", "devspace-vars", "The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled")
 	return deployCmd
 }
 
@@ -161,28 +156,10 @@ func (cmd *DeployCmd) Run(f factory.Factory, plugins []plugin.Metadata, cobraCmd
 		return err
 	}
 
-	// restore vars if wanted
-	if cmd.RestoreVars {
-		vars, _, err := restore.RestoreVarsFromSecret(client, cmd.VarsSecretName)
-		if err != nil {
-			return errors.Wrap(err, "restore vars")
-		}
-
-		generatedConfig.Vars = vars
-	}
-
-	// add current kube context to context
-	config, err := configLoader.Load()
+	// load config
+	config, err := configLoader.RestoreLoadSave(client)
 	if err != nil {
 		return err
-	}
-
-	// save vars if wanted
-	if cmd.SaveVars {
-		err = save.SaveVarsInSecret(client, generatedConfig.Vars, cmd.VarsSecretName)
-		if err != nil {
-			return errors.Wrap(err, "save vars")
-		}
 	}
 
 	// execute plugin hook

--- a/cmd/dev.go
+++ b/cmd/dev.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"github.com/devspace-cloud/devspace/cmd/restore"
-	"github.com/devspace-cloud/devspace/cmd/save"
 	"github.com/devspace-cloud/devspace/pkg/devspace/plugin"
 	"github.com/devspace-cloud/devspace/pkg/devspace/server"
 	"github.com/devspace-cloud/devspace/pkg/devspace/services"
@@ -138,9 +136,6 @@ Open terminal instead of logs:
 	devCmd.Flags().BoolVar(&cmd.Wait, "wait", false, "If true will wait first for pods to be running or fails after given timeout")
 	devCmd.Flags().IntVar(&cmd.Timeout, "timeout", 120, "Timeout until dev should stop waiting and fail")
 
-	devCmd.Flags().BoolVar(&cmd.RestoreVars, "restore-vars", false, "If true will restore the variables from kubernetes before loading the config")
-	devCmd.Flags().BoolVar(&cmd.SaveVars, "save-vars", false, "If true will save the variables to kubernetes after loading the config")
-	devCmd.Flags().StringVar(&cmd.VarsSecretName, "vars-secret", "devspace-vars", "The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled")
 	return devCmd
 }
 
@@ -205,7 +200,7 @@ func (cmd *DevCmd) Run(f factory.Factory, plugins []plugin.Metadata, cobraCmd *c
 
 	// restore vars if wanted
 	if cmd.RestoreVars {
-		vars, _, err := restore.RestoreVarsFromSecret(client, cmd.VarsSecretName)
+		vars, _, err := loader.RestoreVarsFromSecret(client, cmd.VarsSecretName)
 		if err != nil {
 			return errors.Wrap(err, "restore vars")
 		}
@@ -221,7 +216,7 @@ func (cmd *DevCmd) Run(f factory.Factory, plugins []plugin.Metadata, cobraCmd *c
 
 	// save vars if wanted
 	if cmd.SaveVars {
-		err = save.SaveVarsInSecret(client, generatedConfig.Vars, cmd.VarsSecretName)
+		err = loader.SaveVarsInSecret(client, generatedConfig.Vars, cmd.VarsSecretName)
 		if err != nil {
 			return errors.Wrap(err, "save vars")
 		}

--- a/cmd/flags/flags.go
+++ b/cmd/flags/flags.go
@@ -23,7 +23,10 @@ type GlobalFlags struct {
 	ConfigPath     string
 	Vars           []string
 
-	SwitchContext bool
+	RestoreVars    bool
+	SaveVars       bool
+	VarsSecretName string
+	SwitchContext  bool
 
 	Flags *flag.FlagSet
 }
@@ -56,6 +59,9 @@ func (gf *GlobalFlags) ToConfigOptions() *loader.ConfigOptions {
 		KubeContext:    gf.KubeContext,
 		Namespace:      gf.Namespace,
 		Vars:           gf.Vars,
+		RestoreVars:    gf.RestoreVars,
+		SaveVars:       gf.SaveVars,
+		VarsSecretName: gf.VarsSecretName,
 	}
 }
 
@@ -78,6 +84,10 @@ func SetGlobalFlags(flags *flag.FlagSet) *GlobalFlags {
 	flags.StringVar(&globalFlags.KubeContext, "kube-context", "", "The kubernetes context to use")
 	flags.BoolVarP(&globalFlags.SwitchContext, "switch-context", "s", false, "Switches and uses the last kube context and namespace that was used to deploy the DevSpace project")
 	flags.StringSliceVar(&globalFlags.Vars, "var", []string{}, "Variables to override during execution (e.g. --var=MYVAR=MYVALUE)")
+
+	flags.BoolVar(&globalFlags.RestoreVars, "restore-vars", false, "If true will restore the variables from kubernetes before loading the config")
+	flags.BoolVar(&globalFlags.SaveVars, "save-vars", false, "If true will save the variables to kubernetes after loading the config")
+	flags.StringVar(&globalFlags.VarsSecretName, "vars-secret", "devspace-vars", "The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled")
 
 	return globalFlags
 }

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -59,8 +59,14 @@ func (cmd *PrintCmd) Run(f factory.Factory, plugins []plugin.Metadata, cobraCmd 
 		return errors.New(message.ConfigNotFound)
 	}
 
+	// create kubectl client
+	client, err := f.NewKubeClientFromContext(cmd.KubeContext, cmd.Namespace, cmd.SwitchContext)
+	if err != nil {
+		log.Warnf("Unable to create new kubectl client: %v", err)
+	}
+
 	// Load config
-	loadedConfig, err := configLoader.Load()
+	loadedConfig, err := configLoader.RestoreLoadSave(client)
 	if err != nil {
 		return err
 	}

--- a/cmd/purge.go
+++ b/cmd/purge.go
@@ -110,7 +110,7 @@ func (cmd *PurgeCmd) Run(f factory.Factory, plugins []plugin.Metadata, cobraCmd 
 	}
 
 	// Get config with adjusted cluster config
-	config, err := configLoader.Load()
+	config, err := configLoader.RestoreLoadSave(client)
 	if err != nil {
 		return err
 	}

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -113,7 +113,7 @@ func (cmd *RestartCmd) Run(f factory.Factory, plugins []plugin.Metadata, cobraCm
 	}
 
 	// Get config with adjusted cluster config
-	config, err = configLoader.Load()
+	config, err = configLoader.RestoreLoadSave(client)
 	if err != nil {
 		return err
 	}

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -133,7 +133,7 @@ func (cmd *SyncCmd) Run(f factory.Factory, plugins []plugin.Metadata, cobraCmd *
 
 	var config *latest.Config
 	if configLoader.Exists() {
-		config, err = configLoader.Load()
+		config, err = configLoader.RestoreLoadSave(client)
 		if err != nil {
 			return err
 		}

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -157,7 +157,7 @@ func (cmd *UICmd) RunUI(f factory.Factory, plugins []plugin.Metadata, cobraCmd *
 
 	if configExists {
 		// Load config
-		_, err = configLoader.Load()
+		_, err = configLoader.RestoreLoadSave(client)
 		if err != nil {
 			return err
 		}

--- a/cmd/use/profile.go
+++ b/cmd/use/profile.go
@@ -105,7 +105,7 @@ func (cmd *ProfileCmd) RunUseProfile(f factory.Factory, cobraCmd *cobra.Command,
 	}
 
 	if cmd.Reset {
-		log.Info("Successfully resetted profile")
+		log.Info("Successfully reset profile")
 	} else {
 		log.Infof("Successfully switched to profile '%s'", profileName)
 	}

--- a/pkg/devspace/config/loader/get.go
+++ b/pkg/devspace/config/loader/get.go
@@ -1,6 +1,7 @@
 package loader
 
 import (
+	"github.com/devspace-cloud/devspace/pkg/devspace/kubectl"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -23,6 +24,7 @@ type ConfigLoader interface {
 	Exists() bool
 
 	Load() (*latest.Config, error)
+	RestoreLoadSave(client kubectl.Client) (*latest.Config, error)
 	LoadRaw() (map[interface{}]interface{}, error)
 	LoadWithoutProfile() (*latest.Config, error)
 
@@ -76,6 +78,40 @@ func (l *configLoader) Generated() (*generated.Config, error) {
 	}
 
 	return l.generatedConfig, err
+}
+
+// RestoreLoadSave restores variables from the cluster (if wanted), loads the config and then saves them to the cluster again
+func (l *configLoader) RestoreLoadSave(client kubectl.Client) (*latest.Config, error) {
+	generatedConfig, err := l.Generated()
+	if err != nil {
+		return nil, err
+	}
+
+	// restore vars if wanted
+	if client != nil && l.options.RestoreVars {
+		vars, _, err := RestoreVarsFromSecret(client, l.options.VarsSecretName)
+		if err != nil {
+			return nil, errors.Wrap(err, "restore vars")
+		}
+
+		generatedConfig.Vars = vars
+	}
+
+	// add current kube context to context
+	config, err := l.Load()
+	if err != nil {
+		return nil, err
+	}
+
+	// save vars if wanted
+	if client != nil && l.options.SaveVars {
+		err = SaveVarsInSecret(client, generatedConfig.Vars, l.options.VarsSecretName)
+		if err != nil {
+			return nil, errors.Wrap(err, "save vars")
+		}
+	}
+
+	return config, nil
 }
 
 // SaveGenerated is a convenience method to save the generated config
@@ -139,6 +175,10 @@ type ConfigOptions struct {
 	GeneratedConfig *generated.Config
 	LoadedVars      map[string]string
 	Vars            []string
+
+	RestoreVars    bool
+	SaveVars       bool
+	VarsSecretName string
 }
 
 // Clone clones the config options

--- a/pkg/devspace/config/loader/predefined_vars.go
+++ b/pkg/devspace/config/loader/predefined_vars.go
@@ -62,7 +62,7 @@ var predefinedVars = map[string]func(loader *configLoader) (string, error){
 		return hash[:8], nil
 	},
 	"DEVSPACE_CONTEXT": func(loader *configLoader) (string, error) {
-		_, activeContext, _, err := util.NewClientByContext(loader.options.KubeContext, loader.options.Namespace, false, loader.kubeConfigLoader)
+		_, activeContext, _, _, err := util.NewClientByContext(loader.options.KubeContext, loader.options.Namespace, false, loader.kubeConfigLoader)
 		if err != nil {
 			return "", err
 		}
@@ -70,7 +70,7 @@ var predefinedVars = map[string]func(loader *configLoader) (string, error){
 		return activeContext, nil
 	},
 	"DEVSPACE_NAMESPACE": func(loader *configLoader) (string, error) {
-		_, _, activeNamespace, err := util.NewClientByContext(loader.options.KubeContext, loader.options.Namespace, false, loader.kubeConfigLoader)
+		_, _, activeNamespace, _, err := util.NewClientByContext(loader.options.KubeContext, loader.options.Namespace, false, loader.kubeConfigLoader)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/devspace/config/loader/restore.go
+++ b/pkg/devspace/config/loader/restore.go
@@ -1,0 +1,75 @@
+package loader
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/devspace-cloud/devspace/pkg/devspace/kubectl"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	SecretVarsKey = "vars"
+)
+
+// RestoreVarsFromSecret reads the previously saved vars from a secret in kubernetes
+func RestoreVarsFromSecret(client kubectl.Client, secretName string) (map[string]string, bool, error) {
+	secret, err := client.KubeClient().CoreV1().Secrets(client.Namespace()).Get(context.TODO(), secretName, metav1.GetOptions{})
+	if err != nil {
+		if kerrors.IsNotFound(err) == false {
+			return nil, false, err
+		}
+
+		return map[string]string{}, false, nil
+	} else if secret.Data == nil || len(secret.Data[SecretVarsKey]) == 0 {
+		return map[string]string{}, false, nil
+	}
+
+	vars := map[string]string{}
+	err = json.Unmarshal(secret.Data[SecretVarsKey], &vars)
+	if err != nil {
+		return nil, false, errors.Wrap(err, "unmarshal vars")
+	}
+
+	return vars, true, nil
+}
+
+// SaveVarsInSecret saves the given variables in the given secret with the kubernetes client
+func SaveVarsInSecret(client kubectl.Client, vars map[string]string, secretName string) error {
+	if vars == nil {
+		vars = map[string]string{}
+	}
+
+	// marshal vars
+	bytes, err := json.Marshal(vars)
+	if err != nil {
+		return err
+	}
+
+	secret, err := client.KubeClient().CoreV1().Secrets(client.Namespace()).Get(context.TODO(), secretName, metav1.GetOptions{})
+	if err != nil {
+		if kerrors.IsNotFound(err) == false {
+			return err
+		}
+
+		_, err = client.KubeClient().CoreV1().Secrets(client.Namespace()).Create(context.TODO(), &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: secretName,
+			},
+			Data: map[string][]byte{
+				SecretVarsKey: bytes,
+			},
+		}, metav1.CreateOptions{})
+		return err
+	}
+
+	if secret.Data == nil {
+		secret.Data = map[string][]byte{}
+	}
+
+	secret.Data[SecretVarsKey] = bytes
+	_, err = client.KubeClient().CoreV1().Secrets(client.Namespace()).Update(context.TODO(), secret, metav1.UpdateOptions{})
+	return err
+}

--- a/pkg/devspace/config/loader/testing/fake.go
+++ b/pkg/devspace/config/loader/testing/fake.go
@@ -2,6 +2,7 @@ package testing
 
 import (
 	"fmt"
+	"github.com/devspace-cloud/devspace/pkg/devspace/kubectl"
 
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/generated"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/loader"
@@ -61,6 +62,10 @@ func (f *FakeConfigLoader) LoadFromPath(generatedConfig *generated.Config, path 
 		return nil, errors.New("Couldn't load config")
 	}
 
+	return f.Config, nil
+}
+
+func (f *FakeConfigLoader) RestoreLoadSave(client kubectl.Client) (*latest.Config, error) {
 	return f.Config, nil
 }
 

--- a/pkg/devspace/deploy/deployer/kubectl/builder.go
+++ b/pkg/devspace/deploy/deployer/kubectl/builder.go
@@ -53,25 +53,27 @@ func (k *kustomizeBuilder) Build(manifest string, cmd RunCommand) ([]*unstructur
 }
 
 type kubectlBuilder struct {
-	path      string
-	config    *latest.DeploymentConfig
-	context   string
-	namespace string
+	path        string
+	config      *latest.DeploymentConfig
+	context     string
+	namespace   string
+	isInCluster bool
 }
 
 // NewKubectlBuilder creates a new kubectl manifest builder
-func NewKubectlBuilder(path string, config *latest.DeploymentConfig, context, namespace string) Builder {
+func NewKubectlBuilder(path string, config *latest.DeploymentConfig, context, namespace string, isInCluster bool) Builder {
 	return &kubectlBuilder{
-		path:      path,
-		config:    config,
-		context:   context,
-		namespace: namespace,
+		path:        path,
+		config:      config,
+		context:     context,
+		namespace:   namespace,
+		isInCluster: isInCluster,
 	}
 }
 
 func (k *kubectlBuilder) Build(manifest string, cmd RunCommand) ([]*unstructured.Unstructured, error) {
 	args := []string{"create"}
-	if k.context != "" {
+	if k.context != "" && k.isInCluster == false {
 		args = append(args, "--context", k.context)
 	}
 	if k.namespace != "" {

--- a/pkg/devspace/helm/generic/generic.go
+++ b/pkg/devspace/helm/generic/generic.go
@@ -26,6 +26,7 @@ const stableChartRepo = "https://kubernetes-charts.storage.googleapis.com"
 
 type VersionedClient interface {
 	IsValidHelm(path string) (bool, error)
+	IsInCluster() bool
 	KubeContext() string
 	Command() string
 	DownloadURL() string
@@ -82,7 +83,9 @@ func (c *client) Exec(args []string, helmConfig *latest.HelmConfig) ([]byte, err
 		return nil, err
 	}
 
-	args = append(args, "--kube-context", c.versionedClient.KubeContext())
+	if c.versionedClient.IsInCluster() == false {
+		args = append(args, "--kube-context", c.versionedClient.KubeContext())
+	}
 	result, err := c.exec(c.helmPath, args).Output()
 	if err != nil {
 		if exitError, ok := err.(*exec.ExitError); ok {

--- a/pkg/devspace/helm/v2/client.go
+++ b/pkg/devspace/helm/v2/client.go
@@ -47,6 +47,10 @@ func NewClient(config *latest.Config, kubeClient kubectl.Client, tillerNamespace
 	return c, nil
 }
 
+func (c *client) IsInCluster() bool {
+	return c.kubeClient.IsInCluster()
+}
+
 func (c *client) KubeContext() string {
 	return c.kubeClient.CurrentContext()
 }

--- a/pkg/devspace/helm/v3/client.go
+++ b/pkg/devspace/helm/v3/client.go
@@ -41,6 +41,10 @@ func NewClient(kubeClient kubectl.Client, log log.Logger) (types.Client, error) 
 	return c, nil
 }
 
+func (c *client) IsInCluster() bool {
+	return c.kubeClient.IsInCluster()
+}
+
 func (c *client) KubeContext() string {
 	return c.kubeClient.CurrentContext()
 }

--- a/pkg/devspace/kubectl/testing/client.go
+++ b/pkg/devspace/kubectl/testing/client.go
@@ -26,15 +26,21 @@ var _ kubectl.Client = &Client{}
 
 // Client is a fake implementation of the kubectl.Client interface
 type Client struct {
-	Client       kubernetes.Interface
-	KubeLoader   kubeconfig.Loader
-	IsKubernetes bool
-	Context      string
+	Client             kubernetes.Interface
+	KubeLoader         kubeconfig.Loader
+	IsKubernetes       bool
+	Context            string
+	IsInClusterContext bool
 }
 
 // CurrentContext is a fake implementation of function
 func (c *Client) CurrentContext() string {
 	return c.Context
+}
+
+// IsInCluster is a fake implementation of function
+func (c *Client) IsInCluster() bool {
+	return c.IsInClusterContext
 }
 
 // KubeClient is a fake implementation of function

--- a/pkg/devspace/sync/sync.go
+++ b/pkg/devspace/sync/sync.go
@@ -97,7 +97,7 @@ func NewSync(localPath string, options Options) (*Sync, error) {
 	}
 
 	// We exclude the sync log to prevent an endless loop in upstream
-	options.ExcludePaths = append(options.ExcludePaths, ".devspace/")
+	options.ExcludePaths = append(options.ExcludePaths, ".devspace/logs/")
 
 	// Initialize log
 	if options.Log == nil {


### PR DESCRIPTION
### Changes
- the flags `--save-vars` and `--restore-vars` are now global
- the sync only excludes `.devspace/logs` automatically instead of the complete `.devspace` folder
- fixes an issue where deployment with an in cluster kube context was not possible