### PR TITLE
Selector Improvements

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -5,6 +5,7 @@ import (
 	"github.com/devspace-cloud/devspace/pkg/devspace/plugin"
 	"github.com/devspace-cloud/devspace/pkg/devspace/upgrade"
 	"github.com/devspace-cloud/devspace/pkg/util/ptr"
+	"k8s.io/apimachinery/pkg/labels"
 	"os"
 
 	"github.com/devspace-cloud/devspace/cmd/flags"
@@ -191,7 +192,14 @@ func (cmd *SyncCmd) Run(f factory.Factory, plugins []plugin.Metadata, cobraCmd *
 					remotePath = "."
 				}
 
-				syncConfigNames = append(syncConfigNames, fmt.Sprintf("%d: Sync %s (local) <-> %s (container)", idx, localPath, remotePath))
+				selector := ""
+				if sc.ImageName != "" {
+					selector = "image: " + sc.ImageName
+				} else if len(sc.LabelSelector) > 0 {
+					selector = "selector: " + labels.Set(sc.LabelSelector).String()
+				}
+
+				syncConfigNames = append(syncConfigNames, fmt.Sprintf("%d: Sync %s: %s <-> %s ", idx, selector, localPath, remotePath))
 			}
 
 			answer, err := logger.Question(&survey.QuestionOptions{

--- a/pkg/devspace/config/loader/validate.go
+++ b/pkg/devspace/config/loader/validate.go
@@ -196,8 +196,6 @@ func validateDev(config *latest.Config) error {
 				// Validate imageName and label selector
 				if port.ImageName == "" && len(port.LabelSelector) == 0 {
 					return errors.Errorf("Error in config: imageName and label selector are nil in ports config at index %d", index)
-				} else if port.ImageName != "" && len(port.LabelSelector) > 0 {
-					return errors.Errorf("Error in config: imageName and label selector are both set in ports config at index %d. Please only use either one", index)
 				} else if port.ImageName != "" && findImageName(config, port.ImageName) == false {
 					return errors.Errorf("Error in config: dev.ports[%d].imageName '%s' couldn't be found. Please make sure the image name exists under 'images'", index, port.ImageName)
 				}
@@ -213,8 +211,6 @@ func validateDev(config *latest.Config) error {
 				// Validate imageName and label selector
 				if sync.ImageName == "" && len(sync.LabelSelector) == 0 {
 					return errors.Errorf("Error in config: imageName and label selector are nil in sync config at index %d", index)
-				} else if sync.ImageName != "" && len(sync.LabelSelector) > 0 {
-					return errors.Errorf("Error in config: imageName and label selector are both set in sync config at index %d. Please only use either one", index)
 				} else if sync.ImageName != "" && findImageName(config, sync.ImageName) == false {
 					return errors.Errorf("Error in config: dev.sync[%d].imageName '%s' couldn't be found. Please make sure the image name exists under 'images'", index, sync.ImageName)
 				}

--- a/pkg/devspace/configure/image.go
+++ b/pkg/devspace/configure/image.go
@@ -3,6 +3,7 @@ package configure
 import (
 	contextpkg "context"
 	"fmt"
+	"github.com/devspace-cloud/devspace/pkg/devspace/kubectl"
 	"io/ioutil"
 	"os/exec"
 	"regexp"
@@ -12,7 +13,6 @@ import (
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/versions/latest"
 	v1 "github.com/devspace-cloud/devspace/pkg/devspace/config/versions/latest"
 	"github.com/devspace-cloud/devspace/pkg/devspace/docker"
-	"github.com/devspace-cloud/devspace/pkg/devspace/pullsecrets"
 	"github.com/devspace-cloud/devspace/pkg/util/ptr"
 	"github.com/devspace-cloud/devspace/pkg/util/survey"
 	"github.com/pkg/errors"
@@ -113,7 +113,7 @@ func (m *manager) newImageConfigFromDockerfile(imageName, dockerfile, context st
 			DefaultValue:      dockerUsername + "/" + imageName,
 			ValidationMessage: "Please enter a valid image name for Docker Hub (e.g. myregistry.com/user/repository | allowed charaters: /, a-z, 0-9)",
 			ValidationFunc: func(name string) error {
-				_, err := pullsecrets.GetStrippedDockerImageName(name)
+				_, err := kubectl.GetStrippedDockerImageName(name)
 				return err
 			},
 		})
@@ -121,7 +121,7 @@ func (m *manager) newImageConfigFromDockerfile(imageName, dockerfile, context st
 			return nil, err
 		}
 
-		imageName, _ = pullsecrets.GetStrippedDockerImageName(imageName)
+		imageName, _ = kubectl.GetStrippedDockerImageName(imageName)
 	} else if regexp.MustCompile("^(.+\\.)?gcr.io$").Match([]byte(registryURL)) { // Is google registry?
 		project, err := exec.Command("gcloud", "config", "get-value", "project").Output()
 		gcloudProject := "myGCloudProject"
@@ -135,7 +135,7 @@ func (m *manager) newImageConfigFromDockerfile(imageName, dockerfile, context st
 			DefaultValue:      registryURL + "/" + gcloudProject + "/" + imageName,
 			ValidationMessage: "Please enter a valid Docker image name (e.g. myregistry.com/user/repository | allowed charaters: /, a-z, 0-9)",
 			ValidationFunc: func(name string) error {
-				_, err := pullsecrets.GetStrippedDockerImageName(name)
+				_, err := kubectl.GetStrippedDockerImageName(name)
 				return err
 			},
 		})
@@ -143,7 +143,7 @@ func (m *manager) newImageConfigFromDockerfile(imageName, dockerfile, context st
 			return nil, err
 		}
 
-		imageName, _ = pullsecrets.GetStrippedDockerImageName(imageName)
+		imageName, _ = kubectl.GetStrippedDockerImageName(imageName)
 	} else {
 		if dockerUsername == "" {
 			dockerUsername = "username"
@@ -160,7 +160,7 @@ func (m *manager) newImageConfigFromDockerfile(imageName, dockerfile, context st
 			DefaultValue:      repoURL,
 			ValidationMessage: "Please enter a valid docker image name (e.g. myregistry.com/user/repository)",
 			ValidationFunc: func(name string) error {
-				_, err := pullsecrets.GetStrippedDockerImageName(name)
+				_, err := kubectl.GetStrippedDockerImageName(name)
 				return err
 			},
 		})
@@ -168,7 +168,7 @@ func (m *manager) newImageConfigFromDockerfile(imageName, dockerfile, context st
 			return nil, err
 		}
 
-		imageName, _ = pullsecrets.GetStrippedDockerImageName(imageName)
+		imageName, _ = kubectl.GetStrippedDockerImageName(imageName)
 	}
 
 	targets, err := helper.GetDockerfileTargets(dockerfile)

--- a/pkg/devspace/deploy/deployer/util/replace.go
+++ b/pkg/devspace/deploy/deployer/util/replace.go
@@ -4,7 +4,7 @@ import (
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/generated"
 	"github.com/devspace-cloud/devspace/pkg/devspace/config/versions/latest"
 	"github.com/devspace-cloud/devspace/pkg/devspace/deploy/deployer/kubectl/walk"
-	"github.com/devspace-cloud/devspace/pkg/devspace/pullsecrets"
+	"github.com/devspace-cloud/devspace/pkg/devspace/kubectl"
 	"regexp"
 )
 
@@ -55,7 +55,7 @@ func replaceImageNames(cache *generated.CacheConfig, imagesConf map[string]*late
 		}
 
 		// Strip tag from image
-		image, err := pullsecrets.GetStrippedDockerImageName(value)
+		image, err := kubectl.GetStrippedDockerImageName(value)
 		if err != nil {
 			return false
 		}
@@ -87,7 +87,7 @@ func replaceImageNames(cache *generated.CacheConfig, imagesConf map[string]*late
 			value = onlyImage
 		}
 
-		image, err := pullsecrets.GetStrippedDockerImageName(value)
+		image, err := kubectl.GetStrippedDockerImageName(value)
 		if err != nil {
 			return false, nil
 		}

--- a/pkg/devspace/pullsecrets/util.go
+++ b/pkg/devspace/pullsecrets/util.go
@@ -1,8 +1,6 @@
 package pullsecrets
 
 import (
-	"strings"
-
 	"github.com/docker/distribution/reference"
 	dockerregistry "github.com/docker/docker/registry"
 )
@@ -24,27 +22,4 @@ func GetRegistryFromImageName(imageName string) (string, error) {
 	}
 
 	return repoInfo.Index.Name, nil
-}
-
-// GetStrippedDockerImageName returns a tag stripped image name and checks if it's a valid image name
-func GetStrippedDockerImageName(imageName string) (string, error) {
-	imageName = strings.TrimSpace(imageName)
-
-	// Check if we can parse the name
-	ref, err := reference.ParseNormalizedNamed(imageName)
-	if err != nil {
-		return "", err
-	}
-
-	repoInfo, err := dockerregistry.ParseRepositoryInfo(ref)
-	if err != nil {
-		return "", err
-	}
-
-	if repoInfo.Index.Official {
-		// strip docker.io and library from image
-		return strings.TrimPrefix(strings.TrimPrefix(reference.TrimNamed(ref).Name(), repoInfo.Index.Name+"/library/"), repoInfo.Index.Name+"/"), nil
-	}
-
-	return reference.TrimNamed(ref).Name(), nil
 }

--- a/pkg/devspace/upgrade/upgrade.go
+++ b/pkg/devspace/upgrade/upgrade.go
@@ -55,6 +55,10 @@ func GetRawVersion() string {
 // SetVersion sets the application version
 func SetVersion(verText string) {
 	if len(verText) > 0 {
+		if verText[0] != 'v' {
+			verText = "v" + verText
+		}
+
 		_version, err := eraseVersionPrefix(verText)
 		if err != nil {
 			log.GetInstance().Errorf("Error parsing version: %v", err)


### PR DESCRIPTION
### Changes
- Improves the way `devspace sync --config ...` asks for a sync path by displaying the image or label selector (#1300)
- Allows to define `dev.sync.imageName` and `dev.sync.labelSelector` simultaneously
- Improves the way devspace searches for imageNames that were not previously deployed and have a tag with '#' (#1301) 
- Fixes an issue where a version without 'v' would result in issues during ui & helper download